### PR TITLE
Add support for string representation of classification targets in CalibratedExplainer class

### DIFF
--- a/src/calibrated_explanations/_VennAbers.py
+++ b/src/calibrated_explanations/_VennAbers.py
@@ -7,6 +7,7 @@ Classes:
 import warnings
 import numpy as np
 import venn_abers as va
+from .utils.helper import convert_targets_to_numeric
 # from scipy.special import logit, expit
 
 class VennAbers:
@@ -24,8 +25,6 @@ class VennAbers:
     Methods:
         __init__(X_cal, y_cal, learner, bins=None, cprobs=None, difficulty_estimator=None):
             Initializes the VennAbers class with calibration data and model.
-        __convert_targets_to_numeric(y):
-            Converts string/categorical target values to numeric while preserving label mapping.
         __predict_proba_with_difficulty(X, bins=None):
             Predicts probabilities with difficulty adjustment.
         predict(X_test, bins=None):
@@ -37,27 +36,8 @@ class VennAbers:
         is_mondrian() -> bool:
             Returns true if Mondrian categories are used.
     """
-    @staticmethod
-    def __convert_targets_to_numeric(y):
-        """Convert string/categorical targets to numeric values while preserving labels.
-        
-        Args:
-            y (array-like): Array of target values that may be strings or categorical.
-            
-        Returns:
-            tuple:
-                - array-like: Numeric version of the target values
-                - dict or None: Mapping of original labels to numeric values if conversion was needed, None otherwise
-        """
-        if any(isinstance(val, str) for val in y) or any(isinstance(val, (np.str_, np.object_)) for val in y):
-            unique_labels = np.unique(y)
-            label_map = {label: i for i, label in enumerate(unique_labels)}
-            numeric_y = np.array([label_map[label] for label in y])
-            return numeric_y, label_map
-        return y, None
-
     def __init__(self, X_cal, y_cal, learner, bins=None, cprobs=None, difficulty_estimator=None):
-        self.y_cal_numeric, self.label_map = self.__convert_targets_to_numeric(y_cal)
+        self.y_cal_numeric, self.label_map = convert_targets_to_numeric(y_cal)
         self.original_labels = y_cal
 
         self.de = difficulty_estimator

--- a/src/calibrated_explanations/utils/helper.py
+++ b/src/calibrated_explanations/utils/helper.py
@@ -423,3 +423,22 @@ def calculate_metrics(uncertainty=None,
         metrics['quadratic_penalty'] = prediction - w * uncertainty ** 2
 
     return metrics if len(metrics) > 1 else metrics[list(metrics.keys())[0]]
+
+def convert_targets_to_numeric(y):
+    """Convert string/categorical targets to numeric values while preserving labels.
+    
+    Args:
+        y (array-like): Array of target values that may be strings or categorical.
+        
+    Returns:
+        tuple:
+            - array-like: Numeric version of the target values
+            - dict or None: Mapping of original labels to numeric values if conversion was needed
+    """
+    if (any(isinstance(val, str) for val in y) or
+            any(isinstance(val, (np.str_, np.object_)) for val in y)):
+        unique_labels = np.unique(y)
+        label_map = {label: i for i, label in enumerate(unique_labels)}
+        numeric_y = np.array([label_map[label] for label in y])
+        return numeric_y, label_map
+    return y, None

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -191,7 +191,6 @@ def test_binary_ce(binary_dataset):
     alternative_explanation.ensured_explanations()
     alternative_explanation.add_conjunctions(max_rule_size=3)
 
-@pytest.mark.skip(reason="Skipping this test for now")
 def test_multiclass_ce_str_target(multiclass_dataset):
     """
     Tests the CalibratedExplainer with a multiclass classification dataset.
@@ -225,7 +224,6 @@ def test_multiclass_ce_str_target(multiclass_dataset):
     alternative_explanation.semi_explanations(only_ensured=True)
     alternative_explanation.counter_explanations(only_ensured=True)
 
-@pytest.mark.skip(reason="Skipping this test for now")
 def test_binary_ce_str_target(binary_dataset):
     """
     Tests the CalibratedExplainer with a binary classification dataset.


### PR DESCRIPTION
This feature branch implements the support for string representation of classification targets and removed skips in tests that test the functionality.