### PR TITLE
docs: remove duplicate Notes sections

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,6 @@
 name: Build and Deploy Docs
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+on: [push, pull_request]
 
 jobs:
   build:

--- a/src/calibrated_explanations/explanations.py
+++ b/src/calibrated_explanations/explanations.py
@@ -409,8 +409,6 @@ class AlternativeExplanations(CalibratedExplanations):
         -----
         Super-explanations are only available for :class:`.AlternativeExplanation` explanations.
 
-        Notes
-        -----
         only_ensured and include_potential can interact in the following way:
         - only_ensured=True, include_potential=True: ensured explanations takes precedence meaning that unless the original explanation 
             is potential, no potential explanations will be included
@@ -447,8 +445,6 @@ class AlternativeExplanations(CalibratedExplanations):
         -----
         Semi-explanations are only available for :class:`.AlternativeExplanation` explanations.
 
-        Notes
-        -----
         only_ensured and include_potential can interact in the following way:
         - only_ensured=True, include_potential=True: ensured explanations takes precedence meaning that unless the original explanation 
             is potential, no potential explanations will be included
@@ -485,8 +481,6 @@ class AlternativeExplanations(CalibratedExplanations):
         -----
         Counter-explanations are only available for :class:`.AlternativeExplanation` explanations.
 
-        Notes
-        -----
         only_ensured and include_potential can interact in the following way:
         - only_ensured=True, include_potential=True: ensured explanations takes precedence meaning that unless the original explanation 
             is potential, no potential explanations will be included
@@ -756,8 +750,6 @@ class CalibratedExplanation(ABC):
         -----
         The function will return the same explanation if the rule is already included or if the feature is categorical.
         
-        Notes
-        -----
         No implementation is provided for the :class:`.FastExplanation` class.
         """
         try:


### PR DESCRIPTION
... to hopefully fix the CI build of docs:

https://github.com/Moffran/calibrated_explanations/actions/runs/11344070717/job/31548027092

Extension error (numpydoc.numpydoc):
Handler <function mangle_signature at 0x7f74ce290430> for event 'autodoc-process-signature' threw an exception (exception: The section Notes appears twice in  Creates an rule condition for a numerical feature with user defined values.