### PR TITLE
Phase 1B (Day 1): Exception hierarchy + mypy scaffolding + ADR updates

### DIFF
--- a/improvement_docs/adrs/ADR-008-explanation-domain-model-and-compat.md
+++ b/improvement_docs/adrs/ADR-008-explanation-domain-model-and-compat.md
@@ -1,0 +1,44 @@
+# ADR-008: Explanation Domain Model & Legacy-Compatibility Strategy
+
+Status: Proposed
+Date: 2025-08-22
+Deciders: Core maintainers
+Reviewers: TBD
+Supersedes: None
+Superseded-by: None
+
+## Context
+
+Issue reported: The current `explanations.py` stores explanation data in a dict with a mix of
+singletons (for instance-level values) and lists/arrays (per-feature rule values).
+This makes iteration/filtering awkward and hard to reason about.
+
+## Decision
+
+Introduce an internal domain model with first-class rule objects:
+
+- `Explanation`: top-level metadata (task, model info, calibration params, provenance), and `rules: list[FeatureRule]`.
+- `FeatureRule`: per-rule payload (feature id/name, predicate/interval, attribution/weight, support, confidence/uncertainty, local details).
+- Build `Explanation` internally from existing pipelines, but keep public APIs and serializers returning the legacy dict shape via an adapter until schema v1 is adopted.
+
+Rationale: improves clarity, enables easy filtering/transforms, and aligns with future schema and visualization work.
+
+## Consequences
+
+- Positive: simpler iteration/filtering, safer invariants, clearer ownership of fields, smoother future schema migration.
+- Negative: adds an adapter layer; requires adapter parity tests and slight maintenance.
+
+## Alternatives
+
+- Keep dict-only approach (status quo): continues complexity and duplication in consumers.
+- Hard break to new dict shape now: would violate deprecation policy and break golden tests.
+
+## Adoption & Migration
+
+- Phase 2: implement domain model (`explanations/models.py`) + adapters; add tests ensuring adapter output matches golden fixtures byte-for-byte.
+- Phase 5: align JSON schema v1 with `rules: []`, provide migration tool legacy→v1; continue supporting legacy until v0.8.0.
+
+## Open Questions
+
+- Do we expose the domain model publicly later? Initial stance: internal only; revisit post v0.7.0.
+- Naming and minimal required fields for `FeatureRule`—finalize in implementation PR.

--- a/improvement_docs/adrs/ADR-009-input-preprocessing-and-mapping-policy.md
+++ b/improvement_docs/adrs/ADR-009-input-preprocessing-and-mapping-policy.md
@@ -1,0 +1,43 @@
+# ADR-009: Input Preprocessing & Mapping Persistence Policy
+
+Status: Proposed
+Date: 2025-08-22
+Deciders: Core maintainers
+Reviewers: TBD
+Supersedes: None
+Superseded-by: None
+
+## Context
+
+Issue reported: The library only supports numeric input natively. Users must call
+`utils.helper.transform_to_numeric` manually to encode DataFrames with text/categorical
+features and manage mappings externally. Native support in the wrapper would improve
+usability and reproducibility.
+
+## Decision
+
+- Keep the core numeric; add preprocessing in the wrapper layer:
+  - `wrap_explainer.py` learns/applies preprocessing (either built-in `transform_to_numeric` or a user-supplied transformer/pipeline).
+  - Add configuration: `auto_encode=True|False|'auto'`, `preprocessor: Optional[Transformer]`, and policy for unseen categories (`'ignore'|'error'`).
+  - Persist mapping artifacts on the explainer; attach mapping metadata to Explanation provenance.
+- Validation (`core/validation.py`) detects DataFrames/non-numeric columns and enforces NaN/dtype policies, returning actionable errors.
+
+## Consequences
+
+- Positive: greatly improved ergonomics; deterministic mappings in predict/online; clearer provenance.
+- Negative: additional complexity in wrapper; need to document behavior and storage.
+
+## Alternatives
+
+- Enforce user-supplied preprocessing only (status quo), which is less friendly and harder to reproduce.
+- Push preprocessing into core classes, which couples responsibilities and complicates testing/design.
+
+## Adoption & Migration
+
+- Phase 1B: extend validation to be DataFrame-aware.
+- Phase 2: introduce wrapper preprocessing options, persist mappings, and round-trip tests; document configs.
+
+## Open Questions
+
+- Where to store mappings (in-memory only vs. optional serialization helpers)? Start in-memory with API hooks for export/import.
+- Default `auto_encode` value and policy for unseen categories; propose default `'auto'` and `'error'` respectively, reconsider after user feedback.

--- a/src/calibrated_explanations/core/exceptions.py
+++ b/src/calibrated_explanations/core/exceptions.py
@@ -1,0 +1,63 @@
+"""Custom exception hierarchy for calibrated_explanations (Phase 1B).
+
+These exceptions standardize error signaling across the core library without
+changing the existing successful code paths.
+
+Do not export these in the package-level ``calibrated_explanations.core.__all__`` yet
+(to avoid API surface churn). Import them from this module directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "CalibratedError",
+    "ValidationError",
+    "DataShapeError",
+    "ConfigurationError",
+    "ModelNotSupportedError",
+    "NotFittedError",
+    "ConvergenceError",
+    "SerializationError",
+]
+
+
+class CalibratedError(Exception):
+    """Base class for library-specific errors."""
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details: dict[str, Any] | None = details
+
+    def __repr__(self) -> str:  # pragma: no cover - repr stability check in tests
+        cls = self.__class__.__name__
+        return f"{cls}({super().__str__()!r})"
+
+
+class ValidationError(CalibratedError):
+    """Inputs or configuration failed validation."""
+
+
+class DataShapeError(ValidationError):
+    """Provided data has incompatible shape or dtype (e.g., X/y mismatch)."""
+
+
+class ConfigurationError(CalibratedError):
+    """Invalid or conflicting configuration/parameter combination."""
+
+
+class ModelNotSupportedError(CalibratedError):
+    """Unsupported model type or missing required methods for task (e.g., predict_proba)."""
+
+
+class NotFittedError(CalibratedError):
+    """Operation requires a fitted estimator/explainer."""
+
+
+class ConvergenceError(CalibratedError):
+    """Optimization or calibration failed to converge within limits."""
+
+
+class SerializationError(CalibratedError):
+    """Failed to serialize/deserialize explanation artifacts."""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,30 @@
+from calibrated_explanations.core.exceptions import (
+    CalibratedError,
+    ConfigurationError,
+    ConvergenceError,
+    DataShapeError,
+    ModelNotSupportedError,
+    NotFittedError,
+    SerializationError,
+    ValidationError,
+)
+
+
+def test_exception_hierarchy_is_consistent():
+    assert issubclass(ValidationError, CalibratedError)
+    assert issubclass(DataShapeError, ValidationError)
+    assert issubclass(ConfigurationError, CalibratedError)
+    assert issubclass(ModelNotSupportedError, CalibratedError)
+    assert issubclass(NotFittedError, CalibratedError)
+    assert issubclass(ConvergenceError, CalibratedError)
+    assert issubclass(SerializationError, CalibratedError)
+
+
+def test_exceptions_carry_details_dict_and_repr():
+    e = ValidationError("bad input", details={"code": "VAL_INPUT", "param": "X"})
+    assert isinstance(e, Exception)
+    assert e.details == {"code": "VAL_INPUT", "param": "X"}
+    # repr should include class name and message, but not necessarily details
+    r = repr(e)
+    assert "ValidationError" in r
+    assert "bad input" in r


### PR DESCRIPTION
Summary

Introduces a project-wide exception taxonomy and initial tests to anchor Phase 1B stability work. Accepts ADR-002 and adds scoped mypy checks. Documents two reported issues via new ADRs.
Changes

New: exceptions.py (exception hierarchy per ADR-002)
New: test_exceptions.py (hierarchy, details, isinstance checks)
ADR: ADR-002-validation-and-exception-design.md → Accepted with taxonomy/module paths
ADRs: ADR-008 (Explanation domain model + legacy-compat) and ADR-009 (Input preprocessing & mapping policy)
Action Plan: ACTION_PLAN.md updated to reference the two reported issues and ADRs
Types/CI: mypy config in pyproject.toml + GitHub Actions mypy job scoped to Phase 1B files
Contributing: CONTRIBUTING.md updated to highlight Action Plan/ADRs and quality gates
Verification

Lint passes (ruff, markdownlint)
mypy passes on new/targeted modules (scoped workflow)
Tests pass for test_exceptions.py
No public behavior change; no wiring of exceptions across legacy code yet
Backward compatibility

No breaking changes; only new exceptions and docs.