### PR TITLE
Docs: surface Action Plan & ADRs + PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+# Pull Request
+
+## Summary
+
+- What does this PR change? Why?
+
+## Checklist
+
+- [ ] Aligned with current phase in `improvement_docs/ACTION_PLAN.md` (link section)
+- [ ] Referenced relevant ADR(s) in `improvement_docs/adrs/` (IDs)
+- [ ] Added/updated tests for new or changed behavior
+- [ ] mypy passes for touched modules (and strict for new core modules)
+- [ ] Ruff and Markdown lint pass locally
+- [ ] Updated docs/README if public behavior or user flows changed
+- [ ] Considered backward compatibility and deprecation notes
+
+## Screenshots/Notes (optional)
+
+- Any UI/log/output snippets that help reviewers
+
+## Breaking changes (if any)
+
+- [ ] Documented in CHANGELOG with migration notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,54 @@ I'm really glad you're reading this, because we need volunteer developers to hel
 
 Since we are now open to contributions, we welcome your feedback, suggestions, and contributions. You can contribute by opening a pull request, filing an issue, or initiating discussions in our [discussion forum](https://github.com/Moffran/calibrated_explanations/discussions). We value your input and look forward to collaborating with you.
 
+## Roadmap and ADR-driven development
+
+This project follows a written Action Plan and Architecture Decision Records (ADRs):
+
+- Action Plan: see `improvement_docs/ACTION_PLAN.md`. It defines phases (1A–6) and milestone slices. Please align PRs with the current phase and its scope.
+- ADRs: see `improvement_docs/adrs/`. If your change affects architecture, public API, serialization schema, or cross-cutting behavior, add/update an ADR (status `Proposed` → `Accepted` on merge).
+
+Current highlights coming from reported issues and the Action Plan:
+
+- Explanation storage redesign (internal domain model with rule objects), tracked in ADR-008.
+- Native non-numeric input support in the wrapper (preprocessing + mapping persistence), tracked in ADR-009.
+
+Prefer small, focused PRs that map to the plan’s daily/weekly slices (e.g., `feat/1b-exceptions`, `feat/1b-validation`).
+
+
 ## Feature requests
+
 File a new feature request by opening an issue and using the feature request template. Please make sure that the feature request is not already listed in the [enhancement issues](https://github.com/Moffran/calibrated_explanations/labels/enhancement).
 
+
 ## Bug reports
+
 File a new bug report by opening an issue and using the bug report template. Please make sure that the bug is not already listed in the [bug issues](https://github.com/Moffran/calibrated_explanations/labels/bug).
 
+
 ## Pull requests
+
 Please send pull requests through the
 [PR tracker on GitHub](https://github.com/Moffran/calibrated_explanations/pulls).
 Include tests to ensure your contribution is compatible with the tested use cases.
 We have CI set up,
 so watch out for the automated test results.
 
+PR expectations:
+
+- Keep changes scoped to a single slice/milestone. Write a brief checklist in the PR description referencing the Action Plan section.
+- Add/adjust tests: unit tests for new modules/paths, and keep golden/API snapshot tests unchanged unless the Action Plan explicitly calls for a public change (then update snapshots intentionally).
+- Quality gates should pass: ruff lint/format, pytest, and mypy. New modules may be subject to stricter mypy settings (see `pyproject.toml`).
+- If touching performance-sensitive paths, run or reference the perf guard and baseline scripts in `benchmarks/` and `scripts/`.
+- For architectural/public changes, include/modify an ADR in `improvement_docs/adrs/` and link it in the PR.
+
+
 ## Testing and Code Coverage
+
 We use pytest as our testing framework and aim to achieve a code coverage of about 90% in our tests. This ensures that our code is thoroughly tested and helps identify any potential issues or bugs. We encourage contributors to write comprehensive tests and strive for high code coverage. Code coverage tests are added and monitored at [Codecov](https://app.codecov.io/github/Moffran/calibrated_explanations).
+
+Additional checks:
+
+- Linting via ruff (style and simple correctness rules).
+- Type checking via mypy. During Phase 1B, new core modules (e.g., `core/exceptions.py`, `core/validation.py`) are checked with stricter settings.
+- Performance guard: see `scripts/check_perf_regression.py` and `benchmarks/perf_thresholds.json`.

--- a/README.md
+++ b/README.md
@@ -562,13 +562,24 @@ the project page on [GitHub](https://github.com/Moffran/calibrated_explanations)
 You can find a detailed guide for contributions in
 [CONTRIBUTING.md](https://github.com/Moffran/calibrated_explanations/blob/main/CONTRIBUTING.md).
 
+### Roadmap and ADRs
+
+We are evolving the package according to a written Action Plan and ADRs:
+
+- Action Plan: see `improvement_docs/ACTION_PLAN.md` in the repository. Phases guide what changes are accepted at any given time.
+- ADRs: see `improvement_docs/adrs/` for accepted and proposed architectural decisions.
+
+When opening a PR, please align with the current phase and reference the relevant Action Plan sections/ADRs. The PR template includes a short checklist to help.
+
 [Table of Content](#table-of-contents)
+
 
 
 ## Documentation
 For documentation, see [calibrated-explanations.readthedocs.io](https://calibrated-explanations.readthedocs.io/en/latest/?badge=latest).
 
 [Table of Content](#table-of-contents)
+
 
 
 ## License
@@ -594,6 +605,7 @@ modification, are permitted provided that the following conditions are met:
 ## Further Reading and Citing
 
 If you use `calibrated-explanations` for a scientific publication, you are kindly requested to cite one of the following papers:
+
 ### Published Papers
 - [Löfström, H](https://github.com/Moffran). (2023). [Trustworthy explanations: Improved decision support through well-calibrated uncertainty quantification](https://www.diva-portal.org/smash/record.jsf?pid=diva2%3A1810440&dswid=6197) (Doctoral dissertation, Jönköping University, Jönköping International Business School).
 - [Löfström, H](https://github.com/Moffran)., [Löfström, T](https://github.com/tuvelofstrom)., Johansson, U., and Sönströd, C. (2024). [Calibrated Explanations: with Uncertainty Information and Counterfactuals](https://doi.org/10.1016/j.eswa.2024.123154). Expert Systems with Applications, 1-27.
@@ -605,14 +617,17 @@ The paper that originated the idea of `calibrated-explanations` is:
 
 - [Löfström, H.](https://github.com/Moffran), [Löfström, T.](https://github.com/tuvelofstrom), Johansson, U., & Sönströd, C. (2023). [Investigating the impact of calibration on the quality of explanations](https://link.springer.com/article/10.1007/s10472-023-09837-2). Annals of Mathematics and Artificial Intelligence, 1-18. [Code and results](https://github.com/tuvelofstrom/calibrating-explanations).
 
-### Preprints:
+
+### Preprints
 - [Löfström, H](https://github.com/Moffran)., [Löfström, T](https://github.com/tuvelofstrom)., and [Hallberg Szabadvary, J](https://github.com/egonmedhatten). (2024). [Ensured: Explanations for Decreasing the Epistemic Uncertainty in Predictions](https://arxiv.org/abs/2410.05479). arXiv preprint arXiv:2410.05479.
 - [Löfström, T](https://github.com/tuvelofstrom)., [Rabia Yapicioglu, F](https://github.com/rabia174)., Stramiglio A., [Löfström, H](https://github.com/Moffran)., and Vitali F. (2024). [Fast Calibrated Explanations: Efficient and Uncertainty-Aware Explanations for Machine Learning Models](https://arxiv.org/abs/2410.21129). arXiv preprint arXiv:2410.21129.
+
 
 ### Citing and Bibtex
 If you use `calibrated-explanations` for a scientific publication, you are kindly requested to cite one of the papers above. Bibtex entries can be found in [citing](https://github.com/Moffran/calibrated_explanations/blob/main/docs/citing.md#bibtex-entries).
 
 [Table of Content](#table-of-contents)
+
 
 
 ## Acknowledgements
@@ -635,12 +650,12 @@ The `check_is_fitted` and `safe_instance` functions in `calibrated_explanations.
 [Table of Content](#table-of-contents)
 
 
+
 ## Support
 For any questions or issues, please open an [issue](https://github.com/Moffran/calibrated_explanations/issues), open a [discussion](https://github.com/Moffran/calibrated_explanations/discussions) or contact the maintainers.
 
 [Table of Content](#table-of-contents)
 
-[build-log]:    https://github.com/Moffran/calibrated_explanations/actions/workflows/test.yml
-[build-status]: https://github.com/Moffran/calibrated_explanations/actions/workflows/test.yml/badge.svg
+
 [pypi-version]: https://img.shields.io/pypi/v/calibrated-explanations
 [calibrated-explanations-on-pypi]: https://pypi.org/project/calibrated-explanations

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,19 @@
+# Contributing and Roadmap
+
+Contributions are welcome. Please see the repository’s `CONTRIBUTING.md` for the full guide.
+
+## Roadmap-driven development
+
+We are updating the package according to a written Action Plan and ADRs:
+
+- Action Plan: `improvement_docs/ACTION_PLAN.md` in the repo. Phases guide what kinds of changes are in-scope.
+- ADRs: `improvement_docs/adrs/` contains accepted and proposed architectural decisions.
+
+When opening a PR, please align with the current phase and reference the relevant Action Plan sections and ADRs.
+
+## Quality gates (summary)
+
+- Type checks: mypy for new/modified core modules.
+- Linting: ruff and markdownlint.
+- Tests: add unit tests for new behavior; keep runtime reasonable.
+- Docs: update README/docs when public behavior changes.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,8 @@ Contents
 
     getting_started
     citing
+   contributing
+   pr_guide
     calibrated_explanations
 
 Introduction

--- a/docs/pr_guide.md
+++ b/docs/pr_guide.md
@@ -1,0 +1,13 @@
+# Pull Request Guide
+
+Use the GitHub PR template provided in `.github/pull_request_template.md`.
+
+Key items to verify before submitting:
+
+1. Align with current phase in `improvement_docs/ACTION_PLAN.md` and reference relevant ADRs.
+2. Add or update tests for new behavior and ensure they pass locally.
+3. Run mypy for changed modules and ruff/markdownlint for style.
+4. Update README/docs when public behavior changes.
+5. Note breaking changes with migration notes; update CHANGELOG when applicable.
+
+This page is a convenience summary; the authoritative checklist lives in the PR template.

--- a/improvement_docs/adrs/ADR-008-explanation-domain-model-and-compat.md
+++ b/improvement_docs/adrs/ADR-008-explanation-domain-model-and-compat.md
@@ -1,0 +1,44 @@
+# ADR-008: Explanation Domain Model & Legacy-Compatibility Strategy
+
+Status: Proposed
+Date: 2025-08-22
+Deciders: Core maintainers
+Reviewers: TBD
+Supersedes: None
+Superseded-by: None
+
+## Context
+
+Issue reported: The current `explanations.py` stores explanation data in a dict with a mix of
+singletons (for instance-level values) and lists/arrays (per-feature rule values).
+This makes iteration/filtering awkward and hard to reason about.
+
+## Decision
+
+Introduce an internal domain model with first-class rule objects:
+
+- `Explanation`: top-level metadata (task, model info, calibration params, provenance), and `rules: list[FeatureRule]`.
+- `FeatureRule`: per-rule payload (feature id/name, predicate/interval, attribution/weight, support, confidence/uncertainty, local details).
+- Build `Explanation` internally from existing pipelines, but keep public APIs and serializers returning the legacy dict shape via an adapter until schema v1 is adopted.
+
+Rationale: improves clarity, enables easy filtering/transforms, and aligns with future schema and visualization work.
+
+## Consequences
+
+- Positive: simpler iteration/filtering, safer invariants, clearer ownership of fields, smoother future schema migration.
+- Negative: adds an adapter layer; requires adapter parity tests and slight maintenance.
+
+## Alternatives
+
+- Keep dict-only approach (status quo): continues complexity and duplication in consumers.
+- Hard break to new dict shape now: would violate deprecation policy and break golden tests.
+
+## Adoption & Migration
+
+- Phase 2: implement domain model (`explanations/models.py`) + adapters; add tests ensuring adapter output matches golden fixtures byte-for-byte.
+- Phase 5: align JSON schema v1 with `rules: []`, provide migration tool legacy→v1; continue supporting legacy until v0.8.0.
+
+## Open Questions
+
+- Do we expose the domain model publicly later? Initial stance: internal only; revisit post v0.7.0.
+- Naming and minimal required fields for `FeatureRule`—finalize in implementation PR.

--- a/improvement_docs/adrs/ADR-009-input-preprocessing-and-mapping-policy.md
+++ b/improvement_docs/adrs/ADR-009-input-preprocessing-and-mapping-policy.md
@@ -1,0 +1,43 @@
+# ADR-009: Input Preprocessing & Mapping Persistence Policy
+
+Status: Proposed
+Date: 2025-08-22
+Deciders: Core maintainers
+Reviewers: TBD
+Supersedes: None
+Superseded-by: None
+
+## Context
+
+Issue reported: The library only supports numeric input natively. Users must call
+`utils.helper.transform_to_numeric` manually to encode DataFrames with text/categorical
+features and manage mappings externally. Native support in the wrapper would improve
+usability and reproducibility.
+
+## Decision
+
+- Keep the core numeric; add preprocessing in the wrapper layer:
+  - `wrap_explainer.py` learns/applies preprocessing (either built-in `transform_to_numeric` or a user-supplied transformer/pipeline).
+  - Add configuration: `auto_encode=True|False|'auto'`, `preprocessor: Optional[Transformer]`, and policy for unseen categories (`'ignore'|'error'`).
+  - Persist mapping artifacts on the explainer; attach mapping metadata to Explanation provenance.
+- Validation (`core/validation.py`) detects DataFrames/non-numeric columns and enforces NaN/dtype policies, returning actionable errors.
+
+## Consequences
+
+- Positive: greatly improved ergonomics; deterministic mappings in predict/online; clearer provenance.
+- Negative: additional complexity in wrapper; need to document behavior and storage.
+
+## Alternatives
+
+- Enforce user-supplied preprocessing only (status quo), which is less friendly and harder to reproduce.
+- Push preprocessing into core classes, which couples responsibilities and complicates testing/design.
+
+## Adoption & Migration
+
+- Phase 1B: extend validation to be DataFrame-aware.
+- Phase 2: introduce wrapper preprocessing options, persist mappings, and round-trip tests; document configs.
+
+## Open Questions
+
+- Where to store mappings (in-memory only vs. optional serialization helpers)? Start in-memory with API hooks for export/import.
+- Default `auto_encode` value and policy for unseen categories; propose default `'auto'` and `'error'` respectively, reconsider after user feedback.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,7 @@ indent-style = "space"
 skip-magic-trailing-comma = false
 
 [tool.mypy]
-python_version = "3.8"
-packages = ["calibrated_explanations"]
+python_version = "3.11"
 ignore_missing_imports = true
 warn_unused_ignores = true
 warn_return_any = false
@@ -84,6 +83,9 @@ warn_unused_configs = true
 disallow_untyped_defs = false
 show_error_codes = true
 exclude = ["build", "benchmarks", "docs", "notebooks", "scripts", "evaluation"]
+# Keep mypy focused on explicitly provided files in CI and avoid following imports.
+follow_imports = "skip"
+check_untyped_defs = false
 
 # Phase 1B typing: keep permissive defaults; enable stricter checks per-module below.
 [[tool.mypy.overrides]]

--- a/src/calibrated_explanations/core/exceptions.py
+++ b/src/calibrated_explanations/core/exceptions.py
@@ -1,0 +1,63 @@
+"""Custom exception hierarchy for calibrated_explanations (Phase 1B).
+
+These exceptions standardize error signaling across the core library without
+changing the existing successful code paths.
+
+Do not export these in the package-level ``calibrated_explanations.core.__all__`` yet
+(to avoid API surface churn). Import them from this module directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "CalibratedError",
+    "ValidationError",
+    "DataShapeError",
+    "ConfigurationError",
+    "ModelNotSupportedError",
+    "NotFittedError",
+    "ConvergenceError",
+    "SerializationError",
+]
+
+
+class CalibratedError(Exception):
+    """Base class for library-specific errors."""
+
+    def __init__(self, message: str, *, details: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.details: dict[str, Any] | None = details
+
+    def __repr__(self) -> str:  # pragma: no cover - repr stability check in tests
+        cls = self.__class__.__name__
+        return f"{cls}({super().__str__()!r})"
+
+
+class ValidationError(CalibratedError):
+    """Inputs or configuration failed validation."""
+
+
+class DataShapeError(ValidationError):
+    """Provided data has incompatible shape or dtype (e.g., X/y mismatch)."""
+
+
+class ConfigurationError(CalibratedError):
+    """Invalid or conflicting configuration/parameter combination."""
+
+
+class ModelNotSupportedError(CalibratedError):
+    """Unsupported model type or missing required methods for task (e.g., predict_proba)."""
+
+
+class NotFittedError(CalibratedError):
+    """Operation requires a fitted estimator/explainer."""
+
+
+class ConvergenceError(CalibratedError):
+    """Optimization or calibration failed to converge within limits."""
+
+
+class SerializationError(CalibratedError):
+    """Failed to serialize/deserialize explanation artifacts."""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,30 @@
+from calibrated_explanations.core.exceptions import (
+    CalibratedError,
+    ConfigurationError,
+    ConvergenceError,
+    DataShapeError,
+    ModelNotSupportedError,
+    NotFittedError,
+    SerializationError,
+    ValidationError,
+)
+
+
+def test_exception_hierarchy_is_consistent():
+    assert issubclass(ValidationError, CalibratedError)
+    assert issubclass(DataShapeError, ValidationError)
+    assert issubclass(ConfigurationError, CalibratedError)
+    assert issubclass(ModelNotSupportedError, CalibratedError)
+    assert issubclass(NotFittedError, CalibratedError)
+    assert issubclass(ConvergenceError, CalibratedError)
+    assert issubclass(SerializationError, CalibratedError)
+
+
+def test_exceptions_carry_details_dict_and_repr():
+    e = ValidationError("bad input", details={"code": "VAL_INPUT", "param": "X"})
+    assert isinstance(e, Exception)
+    assert e.details == {"code": "VAL_INPUT", "param": "X"}
+    # repr should include class name and message, but not necessarily details
+    r = repr(e)
+    assert "ValidationError" in r
+    assert "bad input" in r


### PR DESCRIPTION
Summary

Improves contributor and user visibility into the development plan and decision records. Adds a PR template with a pre-submit checklist.
Changes

README: Added “Roadmap and ADRs” subsection under Contributing
Docs: Added contributing.md (roadmap-driven dev + quality gates) and pr_guide.md (PR summary checklist); linked both in index.rst
PR Template: pull_request_template.md with checklist (phase alignment, ADR references, tests, mypy/ruff/markdownlint, docs updates, compatibility notes)
Verification

Pre-commit hooks pass (ruff, pip-audit, codespell, EOF/trailing whitespace)
No code changes; tests unaffected
Sphinx ToC updated to include the new pages (same pattern as other .md docs)
Backward compatibility

Docs-only; no runtime impact.