### PR TITLE
Feat/plot plugin dispatch rc2

### DIFF
--- a/.github/ISSUE_TEMPLATE/plugin_publication_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_publication_request.yml
@@ -1,0 +1,77 @@
+name: Plugin intake request
+description: >-
+  Propose a plugin for the calibrated-explanations ecosystem: review for
+  official adoption, promotion of an existing plugin-repository plugin, or a
+  community-plugin listing.
+title: "[plugin]: "
+labels: ["plugin-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing to the calibrated-explanations plugin
+        ecosystem — we're glad you're here! This short form is all we need to
+        get started. If the plugin looks like a fit, the maintainers will
+        follow up about review details (compatibility, PyPI ownership,
+        curation) — none of that is needed now.
+
+        Submitting this form does not authorise publication; maturity and
+        publication decisions rest with the CE plugin maintainers. Community
+        plugins are always welcome to stay independently published.
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Request type
+      options:
+        - Review my plugin for official adoption
+        - Promote an existing plugin-repository plugin to mature
+        - List my community plugin for discoverability
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Plugin location
+      description: >-
+        Repository URL, or the packages/<family>/<name> path for plugins
+        already in the plugin monorepo.
+    validations:
+      required: true
+  - type: dropdown
+    id: family
+    attributes:
+      label: Plugin family
+      options:
+        - calibration
+        - explanation
+        - visualization
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Short description and intended use
+    validations:
+      required: true
+  - type: input
+    id: maintainer
+    attributes:
+      label: Maintainer name and contact
+    validations:
+      required: true
+  - type: input
+    id: licence
+    attributes:
+      label: Licence
+    validations:
+      required: true
+  - type: textarea
+    id: limitations
+    attributes:
+      label: Known limitations
+    validations:
+      required: true
+  - type: input
+    id: tests
+    attributes:
+      label: Tests or CI link (optional)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@
   raises an actionable `ConfigurationError`, and a renderer legitimately
   returning `None` is treated as handled instead of triggering built-in
   plotting. Output transport for third-party styles is renderer-neutral:
-  `filename`/`path` are forwarded verbatim (conflicts raise
-  `ValidationError`), no `plots/` prefix or suffix rewriting is applied, and
-  `show` defaults follow the established save-implies-no-show convention.
+  non-empty `filename`/`path` values are forwarded verbatim (conflicts raise
+  `ValidationError`), exact empty strings retain their historical no-save
+  meaning, no `plots/` prefix or suffix rewriting is applied, and `show`
+  defaults follow the established save-implies-no-show convention. Configured
+  non-legacy plugin styles also remain active when callers explicitly pass
+  `use_legacy=False`, and global regression payload bounds now use the
+  requested `low_high_percentiles`.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@
 
 [Full changelog](https://github.com/Moffran/calibrated_explanations/compare/v1.0.0rc1...main)
 
+### Fixed
+
+- **Third-party plot-plugin dispatch:** fixed third-party visualization
+  dispatch through the public factual, alternative, global, and dashboard
+  plotting APIs. Explicitly selected registered styles now receive their
+  complete plugin option set (`filter_top`, `uncertainty`, `rnk_metric`,
+  `rnk_weight`, `bins`, `low_high_percentiles`, and arbitrary plugin-specific
+  kwargs) and documented runtime context without requiring replacement of CE
+  plotting functions. Explicit plugin failures no longer silently fall through
+  to built-in rendering, an explicitly requested style resolves exactly or
+  raises an actionable `ConfigurationError`, and a renderer legitimately
+  returning `None` is treated as handled instead of triggering built-in
+  plotting. Output transport for third-party styles is renderer-neutral:
+  `filename`/`path` are forwarded verbatim (conflicts raise
+  `ValidationError`), no `plots/` prefix or suffix rewriting is applied, and
+  `show` defaults follow the established save-implies-no-show convention.
+
+### Added
+
+- **`PlotRenderContext.runtime` (additive, trusted plugins only):** a
+  read-only mapping carrying the originating public explainer and original
+  plot request (`x`, `y`, `threshold`, `bins`, `instance_index`) so trusted
+  global/dashboard plugins can drive public explainer APIs without
+  monkey-patching. Populated only after ADR-006 trust resolution; excluded
+  from pickling (restored as an empty mapping). Existing positional and
+  keyword construction of `PlotRenderContext` remains valid.
+- **`PluginManager.resolve_plot_plugin_strict`:** exact-identifier plot style
+  resolution without fallback-chain expansion, used by the public plotting
+  surfaces for explicit third-party style requests.
+
 ## [v1.0.0rc1](https://github.com/Moffran/calibrated_explanations/releases/tag/v1.0.0rc1) - 2026-07-15
 
 [Full changelog](https://github.com/Moffran/calibrated_explanations/compare/v0.11.6...v1.0.0rc1)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,3 +114,16 @@ Notes
 
 If you add or remove optional dependencies, please update `pyproject.toml`,
 `evaluation/requirements.txt`, and `evaluation/environment.yml` accordingly.
+
+Contributing a plugin
+---------------------
+
+Plugins for `calibrated-explanations` are incubated and published from a
+separate plugin repository. Wrote a plugin, or want an existing one promoted
+or listed? Open a short
+["Plugin intake request"](https://github.com/kristinebergs/calibrated_explanations/issues/new?template=plugin_publication_request.yml)
+issue here — a description, maintainer contact, licence, and known
+limitations are all that is needed to start. The maintainers triage requests
+and transfer accepted work into the plugin repository, where new plugins
+start as experimental. Submitting a request does not authorise publication;
+maturity and publication decisions rest with the CE plugin maintainers.

--- a/development/capabilities/evidence/evidence_plot_plugin_dispatch_v1.0.0rc2.md
+++ b/development/capabilities/evidence/evidence_plot_plugin_dispatch_v1.0.0rc2.md
@@ -1,0 +1,212 @@
+# Evidence: third-party plot-plugin dispatch fix (v1.0.0rc2 candidate)
+
+Date: 2026-07-20 (baseline work recorded 2026-07-19)
+Author: automated agent session (Claude Code), evidence verified by execution
+Plan: `development/current-work/v1.0.0-rc2_plan.md`
+
+## Baselines
+
+| Item | Value |
+|---|---|
+| CE baseline SHA | `9573af24e62171040dd872067da2f6aeac884944` (post-RC1 `main`) |
+| CE candidate SHA | `8459df1c` on branch `feat/plot-plugin-dispatch-rc2` (implementation + tests); docs/plans/evidence committed on the same branch after this report |
+| CE `pyproject.toml` version | `1.0.0-dev` (unchanged; preflight tooling owns the RC bump) |
+| v1.0.0rc1 anchor | release commit `0464593a`, PyPI-verified 2026-07-15; tags are authoritative on `Moffran/calibrated_explanations` (none on this mirror) |
+| v1.0.0rc2 | does not exist anywhere (verified 2026-07-19) |
+| Plotly plugin baseline SHA | `f4f7cc84561b032bbc01034f4056543f4bd438b1` (`calibrated-explanations-plugins`, `main`) |
+| Plotly package | `calibrated-explanations-visualization-plotly` 0.3.2, declares `calibrated-explanations>=1.0.0rc1,<2` |
+| Bridge files | `src/ce_visualization_plotly/_ce_compat.py` (installed via `plugin.register_plotly_visualization_components(install_compat_bridges=True)` and re-exported from `__init__.py`) |
+| Plotly no-bridge proof commits | `b545bf4`, `27b6a6d` on local branch `tmp/no-bridge-proof` (not pushed, not published) |
+
+## Root cause (verified executably on baseline, 2026-07-19)
+
+Probe: synthetic builder/renderer/style registered through the public
+registry, called through public plot APIs on baseline `9573af24`:
+
+1. **Factual**: builder invoked only from inside `plot_probabilistic` after
+   `FactualExplanation.plot` consumed `filter_top`/`uncertainty`/
+   `rnk_metric`/`rnk_weight`/`filename` and ranked features. Observed
+   `context.options == {'style', 'vendor_opt', 'instance_index'}`.
+2. **Alternative**: builder **never invoked** — `AlternativeExplanation.plot`
+   calls `plot_alternative()` without `**kwargs`; the `style` kwarg is
+   dropped.
+3. **Global**: builder invoked with `options == {'payload'}` only;
+   `aggregate_positions=True` discarded (with a forwarded-kwargs warning).
+4. **Unknown explicit style** (`vendor.missing`): no error; silently rendered
+   via `plot_spec.default` appended by `resolve_plot_style_chain`.
+5. **`None` renderer result**: `plugin_result is not None` gating caused
+   fall-through into built-in rendering (`_require_matplotlib()` on that
+   path).
+6. **No runtime access**: `PlotRenderContext` had no field carrying the
+   originating explainer or request.
+
+## Files changed (CE candidate)
+
+- `src/calibrated_explanations/plotting.py` — dispatch machinery (+ ~280 lines)
+- `src/calibrated_explanations/explanations/explanation.py` — factual/alternative interception
+- `src/calibrated_explanations/plugins/manager.py` — `resolve_plot_plugin_strict`
+- `src/calibrated_explanations/plugins/plots.py` — `PlotRenderContext.runtime`
+- `tests/unit/test_plot_third_party_dispatch.py` — new (25 tests)
+- `tests/plugins/test_protocols.py` — +5 context tests
+- `tests/unit/test_plot_default_promotion.py`, `tests/unit/test_plotting_coverage.py` — shim adaptations (assertion strength preserved; see plan Task 2)
+- `CHANGELOG.md`, `docs/contributor/plugin-contract.md`, release plans — documentation
+
+## Public API change
+
+- `PlotRenderContext.runtime: Mapping[str, Any] = field(default_factory=dict)`
+  appended after `plugin_config`; positional/keyword backward compatibility
+  and pickle behavior covered by tests. Runtime is trust-gated (ADR-006) and
+  dropped on serialization.
+- `PluginManager.resolve_plot_plugin_strict(identifier, *, renderer_override=None)`
+  → `(plugin, identifier, trusted)`; raises `ConfigurationError` for
+  denied/unregistered/incomplete styles and unresolvable renderer overrides.
+- API snapshot review: **pending** (governed process; see plan checklist).
+
+## Option-forwarding matrix (proven)
+
+| Surface | Options proven to arrive verbatim | Proof |
+|---|---|---|
+| Factual | `filter_top` (incl. default `None`), `uncertainty`, `rnk_metric`, `rnk_weight`, nested `vendor_options` | CE tests + wheel proof `factual options complete` |
+| Alternative | `filter_top`, `rnk_metric`, `rnk_weight`, `vendor_flag`; `style` survives unrewritten | CE tests + wheel proof |
+| Global | `aggregate_positions`, nested `global_options`, `bins`; reserved `payload` added by CE | CE tests + wheel proof `global options preserved` |
+| Dashboard | `factual_options`, `alternative_options`, `available_cards`, `precompute` | CE dashboard test + Plotly proof |
+
+## Transport behavior (proven)
+
+`filename` → `context.path` verbatim (no `plots/` prefix, no suffix rewrite);
+`path` preserved exactly; equal `path`+`filename` accepted; conflicting values
+raise `ValidationError`; output path + omitted `show` → `False`; no output
+path → `True`; explicit `show` wins; `save_ext` list→tuple, absent→`None`
+(no invented static formats). Five dedicated tests.
+
+## Strict resolution and trust behavior (proven)
+
+- Registered trusted style resolves exactly (context.style == requested id).
+- Unregistered explicit style → `ConfigurationError` naming the identifier,
+  the remedy, and the registered styles; message is surface-neutral.
+- `CE_DENY_PLUGIN` denial → `ConfigurationError` at dispatch.
+- Untrusted registered style renders (rc1 parity) but `context.runtime == {}`.
+- Builder error and renderer error propagate; no built-in fallback (built-in
+  plot functions monkeypatched to fail loudly in tests — never called).
+- `style="vendor.x", use_legacy=True` → `ValidationError`; differing string
+  `style_override` → `ValidationError`.
+- Configured-preference fallback (manager/env/pyproject) retains rc1
+  chain semantics with visible `UserWarning` + INFO (existing tests, incl.
+  the adapted renderer-override fallback test).
+
+## `None` renderer-result behavior (proven)
+
+`_PlotDispatchOutcome.handled` is independent of the result; a `None` result
+propagates to the caller and built-in rendering never runs (guarded by
+failing stubs in tests; wheel proof repeats this without Matplotlib
+installed, where any fall-through would raise).
+
+## Test results
+
+- Focused: `tests/unit/test_plot_third_party_dispatch.py` (25) +
+  `tests/plugins/test_protocols.py` (21 incl. 5 new) +
+  `tests/unit/test_plotting.py`, `tests/unit/test_plot_default_promotion.py`,
+  `tests/unit/plugins/test_manager.py`, `tests/plugins/` — all green
+  (2026-07-19/20, Python 3.11 and 3.14 envs).
+- Built-in regression: full `tests/` run excluding `tests/viz` — **exit 0**
+  (2026-07-19, Python 3.11, command
+  `python -m pytest tests -q -x --ignore=tests/viz`). Includes factual
+  regular/legacy/PlotSpec/uncertainty, regression, alternative
+  regular/ensured/triangular, global built-in PlotSpec/legacy, one-sided
+  interval rejection, renderer override, visible-fallback tests.
+- Repository gates (`make local-checks-pr`, docs build, viz lane, CI matrix):
+  **pending** — see plan checklist; do not treat this report as claiming
+  them.
+
+## Installed-wheel evidence (2026-07-19)
+
+- Wheels: `calibrated_explanations-1.0.0.dev0-py3-none-any.whl` (+ sdist)
+  built from candidate `8459df1c` via `uv build`; synthetic plugin
+  `ce_synthetic_viz-0.0.1-py3-none-any.whl` (one factual, one alternative,
+  one global, one dashboard style; public registration + ADR-006 keyed trust
+  helpers; no import-time side effects).
+- Environment: fresh `uv venv` (CPython 3.11.9) at a short path
+  (`%TEMP%\cewp`), packages: calibrated-explanations 1.0.0.dev0,
+  ce-synthetic-viz 0.0.1, numpy 2.4.6, scikit-learn 1.9.0, scipy 1.17.1,
+  pandas 3.0.3, crepes 0.9.1, venn-abers 1.5.3. **Matplotlib absent.**
+- Result: **20/20 checks passed** — wheel-only import (no source tree on
+  `sys.path`), all four styles dispatched with complete options, dashboard
+  drove `explain_factual`/`explore_alternatives` through `context.runtime`,
+  `None` result handled, callable identities unchanged before/after
+  registration and rendering. Raw log: session scratchpad
+  `wheelproof/proof_out.txt` + `wheelproof/env_packages.txt`.
+
+## Plotly no-bridge evidence (2026-07-20)
+
+- Temporary patch (branch `tmp/no-bridge-proof`, commits `b545bf4`,
+  `27b6a6d`): removed `_ce_compat` import from `__init__.py` and bridge
+  installation from `plugin.py` (parameter kept as a no-op);
+  `instance_workspace.py` consumes `context.options["payload"]` and
+  `context.runtime` for dashboard precomputation and strips plot-only keys
+  (`filter_top` etc.) from explain-time kwargs — a latent bridge bug: the old
+  bridge forwarded `factual_options` straight into `explain_factual`, which
+  real CE rejects (`explain_kwargs_schema`); it only passed with fake test
+  explainers.
+- Environment: fresh `uv venv` (CPython 3.11.9, `%TEMP%\cewp2`): CE candidate
+  wheel + patched plotly-plugin wheel (`--no-deps`; the 0.3.2 requirement
+  `>=1.0.0rc1` predates the dev-version wheel), plotly 6.9.0, scikit-learn
+  1.9.0. **Matplotlib absent.**
+- Callable identities of `FactualExplanation.plot`,
+  `AlternativeExplanation.plot`, `plotting.plot_global` recorded before
+  import, after import, after registration, and after rendering **all six**
+  bridge-covered styles — identical throughout; `_ce_compat` never appeared
+  in `sys.modules`; no bridge marker attributes present.
+- Styles exercised through public CE APIs with non-default options
+  (**19/19 checks passed**; raw log: scratchpad
+  `wheelproof/plotly_proof_out.txt`):
+  - `plotly.local.factual_bars` — `filter_top=3, uncertainty=True,
+    rnk_metric="ensured", rnk_weight=0.25`; artifact `options_used` echoed
+    all four; `num_items == 3`; plotly figure produced.
+  - `plotly.local.factual_simple` — `uncertainty=True` honored (consumed
+    directly via CE's preserved `uncertainty` key, no Plotly-specific alias
+    in CE).
+  - `plotly.local.alternative_bars` — `filter_top=4, rnk_metric="ensured",
+    rnk_weight=0.5` echoed; `num_alternatives == 4`.
+  - `plotly.local.alternative_feature_summary` — ran, correct artifact type.
+  - `plotly.global.instance_explorer` — `include_instance_records=True`
+    consumed (8/8 records), `aggregate_positions=True` forwarded; figure
+    produced.
+  - `plotly.dashboard.instance_workspace` — `available_cards="auto",
+    precompute="all", factual_options={"filter_top": 2},
+    alternative_options={"filter_top": 3}`; 8 instances precomputed with
+    local cards generated through `context.runtime["explainer"]`.
+- Static scan of the patched plugin tree (excluding the now-unreferenced
+  `_ce_compat.py`): zero assignments to CE plotting methods, no
+  `__wrapped__` manipulation, no bridge markers, no import-time patching.
+- Trust: styles registered untrusted (`source="entrypoint"`); the proof
+  marked them trusted via the public `mark_plot_builder_trusted`/
+  `mark_plot_renderer_trusted` helpers (operator action), which is what
+  grants the dashboard runtime access.
+
+## Remaining risks
+
+1. Repository gates (`make local-checks-pr`, strict docs build, viz lane,
+   full CI matrix) not yet run at the time of this report — tracked in the
+   plan checklist; RC2 must not be cut before they are green on the exact
+   candidate commit.
+2. Public API snapshot regeneration must go through the governed review, not
+   blind acceptance.
+3. Configured (non-explicit) third-party style preferences retain the rc1
+   chain path, including its `result is not None` gating; a configured (not
+   explicit) plugin returning `None` still falls through to built-in
+   rendering. This is pre-existing rc1 behavior, preserved deliberately to
+   avoid changing governed fallback semantics; flagged for a post-GA cleanup
+   decision.
+4. The Plotly package still ships `_ce_compat.py` on `main`; adopting the
+   no-bridge patch (and raising its CE floor to `>=1.0.0rc2`) is a separate,
+   authorized-later change in the plugins repository.
+5. `FastExplanation.plot` third-party styles remain undefined (documented
+   out of scope).
+
+## Release recommendation
+
+Implementation, contract tests, installed-wheel proof, and the external
+Plotly no-bridge proof are complete and green. Recommend proceeding to the
+release-preparation gates (local-checks, docs, API snapshot review, full CI
+matrix) and then cutting `v1.0.0rc2`. Do not tag or publish before those
+gates are green on the exact candidate commit.

--- a/development/capabilities/evidence/evidence_plot_plugin_dispatch_v1.0.0rc2.md
+++ b/development/capabilities/evidence/evidence_plot_plugin_dispatch_v1.0.0rc2.md
@@ -1,15 +1,62 @@
 # Evidence: third-party plot-plugin dispatch fix (v1.0.0rc2 candidate)
 
-Date: 2026-07-20 (baseline work recorded 2026-07-19)
+Date: 2026-07-20 (baseline work recorded 2026-07-19; independent review and
+correction pass recorded 2026-07-20)
 Author: automated agent session (Claude Code), evidence verified by execution
 Plan: `development/current-work/v1.0.0-rc2_plan.md`
+
+## Independent review and correction pass (2026-07-20)
+
+A second-pass review of the initial implementation (commit `8459df1c`)
+identified three real gaps, verified against actual code/execution before
+any fix was applied:
+
+1. **Configured-preference styles bypassed the raw dispatcher.** The
+   explicit-`style=` interception did not consult
+   `PluginManager.plot_style_override` / `CE_PLOT_STYLE` / pyproject / the
+   plugin-dependency chain, so a third-party style selected through any of
+   those mechanisms still lost `filter_top`/`uncertainty`/`rnk_metric`/
+   `rnk_weight`/options to built-in consumption. Confirmed by executing a
+   configured-style probe against the fixed-but-not-yet-corrected candidate:
+   the plugin was never invoked.
+2. **`style_override` alone (no `style=`) bypassed interception on the
+   factual/alternative surfaces**, while `plot_global` already checked both.
+   Confirmed by executing `factual.plot(style_override="vendor.x", ...)`.
+3. **`resolve_plot_plugin_strict` computed the `trusted` flag before applying
+   `renderer_override`**, so overriding to an untrusted, unrelated renderer
+   inherited the original style's trust and received full runtime access
+   (explainer, model, request data) — a real ADR-006 violation. Confirmed by
+   registering a trusted style, overriding its renderer to a separately
+   registered *untrusted* renderer, and observing a non-empty
+   `context.runtime`.
+
+All three were fixed (see commit `9e1fa1e5`): `resolve_plot_plugin_strict`
+now recomputes trust as `trusted and renderer_descriptor.trusted` whenever a
+renderer override is applied; the three public surfaces now check
+`style_override` alongside `style` for explicit selection and, when neither
+is given, resolve the same configured-preference precedence the built-in
+path already used, dispatching the full raw request through the existing
+strict resolver when it names a registered third-party plugin. A guard
+(`_configured_dispatch_blocked`) preserves the exact pre-existing
+reachability condition for `use_legacy`/`return_plot_spec`/explicit style, so
+none of those combinations changed behavior. Unresolvable configured styles
+fall through to the existing built-in/legacy path unchanged (no broadened
+fallback). 10 new regression tests were added directly reproducing each
+finding (positive and negative), and both the installed-wheel proof and the
+six-style Plotly no-bridge proof were rebuilt and rerun against the
+corrected candidate — all still pass. The reviewer also flagged three gaps
+in the temporary `tmp/no-bridge-proof` plugins-repo branch (stale
+CE floor, a test asserting bridge installation, an implicit trust step);
+all three were corrected there (commit `3629ca9`) since they were concrete
+and verified (one stale assertion was confirmed to fail before the fix).
 
 ## Baselines
 
 | Item | Value |
 |---|---|
 | CE baseline SHA | `9573af24e62171040dd872067da2f6aeac884944` (post-RC1 `main`) |
-| CE candidate SHA | `8459df1c` on branch `feat/plot-plugin-dispatch-rc2` (implementation + tests); docs/plans/evidence committed on the same branch after this report |
+| CE candidate SHA | `9e1fa1e5` on branch `feat/plot-plugin-dispatch-rc2` (implementation `8459df1c` + review-driven correction `9e1fa1e5`); docs/plans/evidence committed on the same branch |
+| Plotly proof candidate | `3629ca9` on local branch `tmp/no-bridge-proof` (supersedes `b545bf4`/`27b6a6d`) |
 | CE `pyproject.toml` version | `1.0.0-dev` (unchanged; preflight tooling owns the RC bump) |
 | v1.0.0rc1 anchor | release commit `0464593a`, PyPI-verified 2026-07-15; tags are authoritative on `Moffran/calibrated_explanations` (none on this mirror) |
 | v1.0.0rc2 | does not exist anywhere (verified 2026-07-19) |
@@ -103,14 +150,21 @@ installed, where any fall-through would raise).
 
 ## Test results
 
-- Focused: `tests/unit/test_plot_third_party_dispatch.py` (25) +
-  `tests/plugins/test_protocols.py` (21 incl. 5 new) +
-  `tests/unit/test_plotting.py`, `tests/unit/test_plot_default_promotion.py`,
+- Focused: `tests/unit/test_plot_third_party_dispatch.py` (31, incl. 10 added
+  during the review-correction pass: configured manager-override dispatch
+  for factual/alternative/global, `None`-result handling on the configured
+  path, `use_legacy=True` still bypassing configured dispatch, unregistered
+  configured styles falling through silently, `style_override`-only
+  selection for factual/alternative, and renderer-override trust
+  recomputation both directions) + `tests/plugins/test_protocols.py`
+  (21 incl. 5 new) + `tests/unit/test_plotting.py`,
+  `tests/unit/test_plot_default_promotion.py`,
   `tests/unit/plugins/test_manager.py`, `tests/plugins/` — all green
   (2026-07-19/20, Python 3.11 and 3.14 envs).
 - Built-in regression: full `tests/` run excluding `tests/viz` — **exit 0**
-  (2026-07-19, Python 3.11, command
-  `python -m pytest tests -q -x --ignore=tests/viz`). Includes factual
+  both before (2026-07-19) and after (2026-07-20) the correction pass, Python
+  3.11, command `python -m pytest tests -q -x --ignore=tests/viz`. Includes
+  factual
   regular/legacy/PlotSpec/uncertainty, regression, alternative
   regular/ensured/triangular, global built-in PlotSpec/legacy, one-sided
   interval rejection, renderer override, visible-fallback tests.
@@ -185,28 +239,44 @@ installed, where any fall-through would raise).
 
 ## Remaining risks
 
-1. Repository gates (`make local-checks-pr`, strict docs build, viz lane,
-   full CI matrix) not yet run at the time of this report — tracked in the
-   plan checklist; RC2 must not be cut before they are green on the exact
-   candidate commit.
-2. Public API snapshot regeneration must go through the governed review, not
+1. **Resolved during the review-correction pass, not a residual risk:**
+   configured (non-explicit) third-party styles that successfully resolve
+   now go through the *same* `_dispatch_third_party_plot`/
+   `_PlotDispatchOutcome` machinery as the explicit path, so a configured
+   plugin legitimately returning `None` is also now treated as handled
+   (test: `test_should_treat_none_renderer_result_as_handled_when_configured_style_dispatched`).
+   An *unresolvable* configured style (unregistered, denied, or no strict
+   resolver reachable) still falls through to the pre-existing built-in/
+   chain-based path unchanged — that fallback governance was deliberately
+   not broadened or narrowed.
+2. `make local-checks-pr`, the ADR-023 viz lane, and packaging validation
+   have been run and are green on the corrected candidate (`9e1fa1e5`,
+   2026-07-20). The full repository-supported CI matrix has **not** run,
+   since the branch has not been pushed — this remains open and RC2 must not
+   be cut before it is green on the exact pushed candidate commit.
+3. Public API snapshot regeneration must go through the governed review, not
    blind acceptance.
-3. Configured (non-explicit) third-party style preferences retain the rc1
-   chain path, including its `result is not None` gating; a configured (not
-   explicit) plugin returning `None` still falls through to built-in
-   rendering. This is pre-existing rc1 behavior, preserved deliberately to
-   avoid changing governed fallback semantics; flagged for a post-GA cleanup
-   decision.
-4. The Plotly package still ships `_ce_compat.py` on `main`; adopting the
-   no-bridge patch (and raising its CE floor to `>=1.0.0rc2`) is a separate,
-   authorized-later change in the plugins repository.
+4. The Plotly package's `main` branch still ships `_ce_compat.py` and
+   declares `>=1.0.0rc1`; the temporary `tmp/no-bridge-proof` branch
+   (candidate `3629ca9`) removes the bridge install/import, raises the floor
+   to `>=1.0.0rc2`, and fixes the three stale bridge-installed test
+   assertions a reviewer identified — but `_ce_compat.py` itself was not
+   deleted (confirmed dead code: unreferenced by `__init__.py`, the
+   registration path, or any runtime dispatch path) and installation docs
+   were not rewritten to make the required operator trust step (marking the
+   dashboard builder/renderer trusted) explicit. Both are scoped to the
+   separately authorized adoption task, per this task's "temporary
+   adaptation, not final integration branch" constraint.
 5. `FastExplanation.plot` third-party styles remain undefined (documented
    out of scope).
 
 ## Release recommendation
 
-Implementation, contract tests, installed-wheel proof, and the external
-Plotly no-bridge proof are complete and green. Recommend proceeding to the
-release-preparation gates (local-checks, docs, API snapshot review, full CI
-matrix) and then cutting `v1.0.0rc2`. Do not tag or publish before those
-gates are green on the exact candidate commit.
+Implementation, contract tests (including the review-driven correction for
+configured-style dispatch, `style_override`-only selection, and
+renderer-override trust recomputation), installed-wheel proof, and the
+external Plotly no-bridge proof are complete and green on the corrected
+candidate. Recommend proceeding to the remaining release-preparation gates
+(push the branch, full CI matrix, API snapshot review) and then cutting
+`v1.0.0rc2`. Do not tag or publish before those gates are green on the exact
+candidate commit.

--- a/development/current-work/RELEASE_PLAN_v1.md
+++ b/development/current-work/RELEASE_PLAN_v1.md
@@ -34,8 +34,8 @@ Detailed ADR/Standard status tables, gap inventories, and historical compliance 
 ### Control snapshot
 
 - **Current released version:** v1.0.0rc1
-- **Active detailed milestone:** v1.0.0 (`development/current-work/v1.0.0_plan.md`)
-- **Next milestone:** v1.0.0
+- **Active detailed milestone:** v1.0.0rc2 (`development/current-work/v1.0.0-rc2_plan.md`) — emergency plot-plugin dispatch compatibility patch; release sequence is now **v1.0.0rc1 → v1.0.0rc2 → v1.0.0**
+- **Next milestone:** v1.0.0 (`development/current-work/v1.0.0_plan.md`; blocked pending v1.0.0rc2, which becomes the GA baseline)
 - **Status appendix:** `development/current-work/RELEASE_PLAN_status_appendix.md`
 
 ### Release-blocking conditions

--- a/development/current-work/v1.0.0-rc2_plan.md
+++ b/development/current-work/v1.0.0-rc2_plan.md
@@ -76,7 +76,11 @@ documented as out of scope in `docs/contributor/plugin-contract.md`.
 
 ### 1) CE-native third-party dispatch implementation
 
-Status: **Complete** (commit `8459df1c`).
+Status: **Complete** (commit `8459df1c`; corrected `9e1fa1e5` after
+independent review found that configured-preference styles,
+`style_override`-only selection, and renderer-override trust recomputation
+were not yet covered — see the evidence report's "Independent review and
+correction pass" section).
 
 - `src/calibrated_explanations/plotting.py`: `_PlotDispatchOutcome`,
   `_is_third_party_plot_style` (CE-owned vocabulary = `regular`, `triangular`,
@@ -162,8 +166,9 @@ factual and global/dashboard examples).
 
 - Evidence report:
   `development/capabilities/evidence/evidence_plot_plugin_dispatch_v1.0.0rc2.md`
-- CE candidate commit: `8459df1c` (branch `feat/plot-plugin-dispatch-rc2`)
-- Plotly proof commits: `b545bf4`, `27b6a6d` (branch `tmp/no-bridge-proof`,
+- CE candidate commit: `9e1fa1e5` (branch `feat/plot-plugin-dispatch-rc2`,
+  supersedes `8459df1c`)
+- Plotly proof commits: `b545bf4`, `27b6a6d`, `3629ca9` (branch `tmp/no-bridge-proof`,
   local only, not pushed/published)
 
 ## Post-publication checks (for the later release task)

--- a/development/current-work/v1.0.0-rc2_plan.md
+++ b/development/current-work/v1.0.0-rc2_plan.md
@@ -1,0 +1,176 @@
+# v1.0.0rc2 Release Task Implementation Plan
+
+> **Release version:** `1.0.0rc2`
+> **Development version:** `1.0.0-dev` (unchanged; the release preflight
+> tooling produces the candidate version — do not hand-pin `1.0.0rc2`)
+
+> **Baseline:** `v1.0.0rc1` (release commit
+> `0464593aeb0a0e89660027e0c94b39ece8142448`, shipped to PyPI 2026-07-15).
+> Plan baselined from post-RC1 `main` at
+> `9573af24e62171040dd872067da2f6aeac884944`.
+> **Baseline note (recorded 2026-07-19):** no `v1.0.0rc1` git tag exists on
+> this repository or its `origin`. Per `RELEASE_PLAN_v1.md` §"Repository
+> authority", `kristinebergs/calibrated_explanations` is a development
+> mirror; tags, releases, and PyPI publication are authoritative on
+> `Moffran/calibrated_explanations`. The RC1 baseline is anchored here by the
+> release commit and the PyPI artifact.
+
+> **Defect classification:** release-blocking emergency compatibility patch
+> under the GA plan's "emergency patch" rule (`v1.0.0_plan.md` Global rules:
+> "A release-blocking defect is an emergency patch (separate change, full
+> gate re-run)"). CE 1.0.0rc1 publicly exposes the plot-plugin architecture
+> (ADR-006/ADR-036/ADR-037), but the public plotting surfaces do not preserve
+> the plugin request end to end, forcing third-party visualization packages
+> to monkey-patch `FactualExplanation.plot`, `AlternativeExplanation.plot`,
+> and `plotting.plot_global` (see the Plotly package's `_ce_compat.py`
+> compatibility bridges). GA must not ship on that contract.
+
+## Governing ADRs
+
+| ADR | Consequence for this change | Classification |
+|---|---|---|
+| ADR-006 (plugin registry trust model) | Runtime access (explainer, request data) is granted to trusted builder+renderer pairs only; deny/trust controls unchanged; untrusted registered styles still render (parity with rc1) but receive an empty runtime mapping | Implementation completion |
+| ADR-036 (PlotSpec canonical contract and validation boundary) | The existing `validate_plot_artifact` boundary runs between `build` and `render` for third-party dispatch; non-PlotSpec renderer-native artifacts pass through unvalidated as before | Implementation completion |
+| ADR-037 (visualization extension and rendering governance) | Builder/renderer/style registration metadata and resolution stay deterministic; no runtime plot-kind extension added | Implementation completion |
+| ADR-020 (legacy user API stability) | All CE-owned style routes (`regular`, `triangular`, `ensured`, `narrative`, `legacy`, `plot_spec.default`, `use_legacy`, `return_plot_spec`, configured defaults) keep their rc1 behavior | Constraint honored |
+| ADR-002 (validation and exception design) | Contradictory explicit requests raise `ValidationError`; resolution failures raise `ConfigurationError` with actionable remedies | Constraint honored |
+| ADR-028 / CONTRIBUTOR_INSTRUCTIONS §5 (fallback visibility) | Configured-preference fallback keeps `UserWarning` + INFO visibility; explicit styles no longer fall back at all | Constraint honored |
+| ADR-030 / STD-003 (test quality, coverage) | New tests follow `test_should_<behavior>_when_<condition>`, public-contract-only assertions | Constraint honored |
+
+No new ADR is required: the change completes the approved plot-plugin
+boundary. The additive `PlotRenderContext.runtime` field is an API addition
+documented in `docs/contributor/plugin-contract.md` and gated by ADR-006
+trust; it does not alter the visualization-extension governance model.
+
+## Defect traceability matrix
+
+Root causes verified executably against baseline `9573af24` on 2026-07-19
+(probe: registered synthetic builder/renderer/style through the public
+registry, then called the public plot APIs).
+
+| # | Compatibility behavior (Plotly `_ce_compat.py`) | Exact CE root cause (baseline) | Public contract that should exist | CE implementation location | CE regression test | External no-bridge proof |
+|---|---|---|---|---|---|---|
+| 1 | Factual bridge injects positional `filter_top` into kwargs | `FactualExplanation.plot` normalizes `filter_top` (`min(num_features, filter_top)`) before dispatch | `context.options["filter_top"]` verbatim, incl. default `None` | `plotting._dispatch_explicit_instance_plot_style` | `test_should_forward_complete_factual_request_when_third_party_style_selected`, `test_should_include_default_filter_top_none_when_factual_plugin_dispatched` | `factual_bars honored filter_top=3` |
+| 2 | Factual bridge translates `uncertainty` → `show_uncertainty` | `plot()` pops `uncertainty` before dispatch | `uncertainty` preserved under that exact name | same | same factual test | `factual_bars received full option set` |
+| 3 | Bridge preserves `rnk_metric` | `plot()` pops and rewrites (`uncertainty`→`ensured`) | verbatim forwarding | same | same | same |
+| 4 | Bridge preserves `rnk_weight` | `plot()` pops (and overrides to 1.0 for `uncertainty` metric) | verbatim forwarding | same | same | same |
+| 5 | Bridge forwards plugin-specific kwargs | kwargs survived but only alongside consumed built-ins | all non-selection/transport kwargs forwarded | `plotting._third_party_plot_options` | factual test (`vendor_options` nested) | dashboard `factual_options`/`alternative_options` |
+| 6 | Alternative bridge injects `filter_top` | `AlternativeExplanation.plot` ranks/filters before dispatch | verbatim forwarding before ranking | same dispatch helper, intercepted at method start | `test_should_forward_complete_alternative_request_when_third_party_style_selected` | `alternative_bars honored filter_top=4` |
+| 7 | Alternative bridge preserves `style` | `plot()` calls `plot_alternative()` **without** `**kwargs` — style dropped entirely (baseline probe: builder never invoked) | style dispatches before built-in alternative plotting | same | same + `test_should_not_rewrite_third_party_style_when_alternative_plugin_dispatched` | `alternative_bars ran with full option set` |
+| 8 | Alternative ranking options | ranking + identical-to-base filtering executed in CE before dispatch | plugin owns ranking; CE must not pre-rank | same (dispatch precedes `rank_features`/`calculate_metrics`) | rank/metrics spies assert zero calls | plugin's own ranking parity tests |
+| 9 | Alternative plugin-specific kwargs | dropped with the `**kwargs` omission | forwarded | same | same | `alternative_feature_summary ran` |
+| 10 | Global bridge resolves `plotly.global.*` styles | `plot_global` resolved via chain that appends `plot_spec.default`/`legacy` and passed `options={"payload": ...}` only | strict exact resolution + full options | `plotting._dispatch_explicit_global_plot_style`, `PluginManager.resolve_plot_plugin_strict` | `test_should_forward_payload_options_and_runtime_when_global_style_selected` | `instance_explorer ran and consumed include_instance_records=True` |
+| 11 | Dashboard bridge resolves `plotly.dashboard.*` | same as #10 | same | same | `test_should_let_trusted_dashboard_plugin_drive_public_explainer_when_dispatched` | `instance_workspace ran through explainer.plot` |
+| 12 | Bridge forwards global/dashboard option payloads | `plot_global` discarded all plugin kwargs (baseline probe: options == `["payload"]`) | all non-transport kwargs preserved | same | same global/dashboard tests | six-style proof `options_used` echoes |
+| 13 | Dashboard bridge precomputes local explanations by calling the explainer | no runtime access; plugins could not reach the originating explainer/request | `context.runtime` (trusted): `scope`/`explainer`/`x`/`y`/`threshold`/`bins`; instance scope: `explainer`/`instance_index` | `PlotRenderContext.runtime` (`plugins/plots.py`) + dispatch helpers | dashboard test + `test_protocols.py` runtime tests | workspace precomputes via `context.runtime` (temporary patch) |
+| 14 | Bridge normalizes `filename`→`path` (coercing `.html`) and save/show defaults | CE applied `prepare_for_saving`, `plots/` prefix, extension splitting | verbatim `path`/`filename` (conflict → `ValidationError`); show default: False iff output path; no suffix rewrite; renderer owns formats | `plotting._normalize_third_party_transport` | transport tests (5) | proof runs with `show=False`; no `plots/` artifacts created |
+| 15 | Bridge bypasses chain fallback for explicit styles | `resolve_plot_style_chain` always appends `plot_spec.default` + `legacy`; unknown explicit style silently rendered `plot_spec.default` (baseline probe) | exact resolution or actionable `ConfigurationError`; builder/renderer errors surface; no fallback | `PluginManager.resolve_plot_plugin_strict` | strict-resolution tests (7) | n/a (CE-side) |
+| 16 | Bridge returns renderer result directly | `plot_probabilistic`/`plot_alternative` used `plugin_result is not None` and fell through to built-in rendering on `None` | `handled` distinct from `result`; `None` propagates without built-in rendering | `plotting._PlotDispatchOutcome` | `test_should_treat_none_renderer_result_as_handled_when_factual_plugin_returns_none` (+ alternative variant) | wheel proof `alternative None result propagates` |
+
+Out-of-scope note: `FastExplanation.plot` documents only CE-owned styles
+(`'regular'`), no ADR or plugin metadata promises third-party fast styles,
+and the Plotly package registers none. Fast plotting is unchanged and
+documented as out of scope in `docs/contributor/plugin-contract.md`.
+
+## Tasks
+
+### 1) CE-native third-party dispatch implementation
+
+Status: **Complete** (commit `8459df1c`).
+
+- `src/calibrated_explanations/plotting.py`: `_PlotDispatchOutcome`,
+  `_is_third_party_plot_style` (CE-owned vocabulary = `regular`, `triangular`,
+  `ensured`, `narrative`, `legacy`, `plot_spec.default`),
+  `_reject_conflicting_plot_selection`, `_normalize_third_party_transport`,
+  `_third_party_plot_options`, `_dispatch_third_party_plot`,
+  `_dispatch_explicit_instance_plot_style`,
+  `_dispatch_explicit_global_plot_style`; `plot_global` routes explicit
+  third-party styles before payload/legacy handling.
+- `src/calibrated_explanations/explanations/explanation.py`:
+  `FactualExplanation.plot` and `AlternativeExplanation.plot` intercept
+  third-party styles as their first action.
+- `src/calibrated_explanations/plugins/manager.py`:
+  `resolve_plot_plugin_strict` (exact identifier; deny/unregistered/incomplete
+  → `ConfigurationError`; renderer-override must resolve or raise; returns
+  trust flag).
+- `src/calibrated_explanations/plugins/plots.py`: additive
+  `PlotRenderContext.runtime` (default `{}`, top-level read-only, dropped on
+  pickle).
+
+### 2) CE synthetic-plugin tests
+
+Status: **Complete**. `tests/unit/test_plot_third_party_dispatch.py` (25
+tests: factual/alternative/global/dashboard forwarding, strict resolution,
+trust gating, transport) + `tests/plugins/test_protocols.py` (5 new
+`PlotRenderContext` construction/read-only/pickle tests). Existing tests
+adapted (not weakened): `test_plot_default_promotion.py` shims now also stub
+the strict resolver and use a renderer-native artifact shape;
+`test_plotting_coverage.py` renderer-override fallback test moved to the
+configured-preference path (explicit styles now raise).
+
+### 3) Installed-wheel proof
+
+Status: **Complete** (see evidence report). CE wheel (no `viz` extra) +
+`ce-synthetic-viz` wheel in a clean Python 3.11 env without Matplotlib; all
+four synthetic styles pass with complete options, runtime dashboard access,
+`None`-result handling, and unchanged callable identities.
+
+### 4) Plotly no-bridge proof
+
+Status: **Complete** (see evidence report). Temporary branch
+`tmp/no-bridge-proof` in `calibrated-explanations-plugins` removes
+`install_ce_plot_bridges()`/`_ce_compat` and ports dashboard precomputation
+onto `context.runtime`. All six bridge-covered styles pass through public CE
+APIs from installed wheels; CE callable identities unchanged throughout.
+
+### 5) Documentation
+
+Status: **Complete**. `CHANGELOG.md` Unreleased entry;
+`docs/contributor/plugin-contract.md` "Third-party style dispatch contract
+(v1.0.0rc2)" section (dispatch timing, built-in vocabulary, strict
+resolution, transport semantics, `context.options`, reserved global
+`payload`, runtime semantics + serialization limits, trust implications,
+artifact validation, result propagation, no-monkey-patching rule, minimal
+factual and global/dashboard examples).
+
+### 6) Release preparation (open)
+
+- [ ] Merge `feat/plot-plugin-dispatch-rc2` to `main` after review.
+- [ ] Run `make release-prepare-files` / `make release-preflight` to produce
+      the `1.0.0rc2` candidate version (do not hand-edit the version).
+- [ ] Tag and publish per `release.md` steps 11–13 (maintainer-only, on the
+      authoritative `Moffran` repository; **not** part of this plan's
+      execution).
+- [ ] `make release-postcommit` verification.
+
+## Verification checklist
+
+- [x] Baseline defect reproduced executably before any edit (2026-07-19).
+- [x] New dispatch + context tests green (30 new tests).
+- [x] Full non-viz test suite green on the branch (exit 0, 2026-07-19).
+- [x] Installed-wheel synthetic-plugin proof: 20/20 checks (2026-07-19).
+- [x] Plotly no-bridge proof: 19/19 checks, six styles (2026-07-20).
+- [ ] `make local-checks-pr` on the candidate commit.
+- [ ] Strict docs build / link check.
+- [ ] Public API snapshot review (`PlotRenderContext.runtime`,
+      `PluginManager.resolve_plot_plugin_strict`) through the governed
+      process.
+- [ ] Full CI matrix green on the exact candidate commit (local runs are not
+      a substitute).
+
+## Candidate evidence
+
+- Evidence report:
+  `development/capabilities/evidence/evidence_plot_plugin_dispatch_v1.0.0rc2.md`
+- CE candidate commit: `8459df1c` (branch `feat/plot-plugin-dispatch-rc2`)
+- Plotly proof commits: `b545bf4`, `27b6a6d` (branch `tmp/no-bridge-proof`,
+  local only, not pushed/published)
+
+## Post-publication checks (for the later release task)
+
+- [ ] `pip install calibrated-explanations==1.0.0rc2` in a clean env; re-run
+      the synthetic-plugin wheel proof against the PyPI artifact.
+- [ ] Plotly package: adopt the no-bridge patch, raise the CE floor to
+      `>=1.0.0rc2`, delete `_ce_compat.py`, re-run its test suite.
+- [ ] Confirm `v1.0.0rc2` (and back-filled `v1.0.0rc1`) tags exist on origin.
+- [ ] Update `RELEASE_PLAN_v1.md` "Current released version" to `v1.0.0rc2`.

--- a/development/current-work/v1.0.0_plan.md
+++ b/development/current-work/v1.0.0_plan.md
@@ -8,6 +8,25 @@
 > verified by `make release-postcommit`). Plan archived at
 > `development/finished-work/v1.0.0-rc_plan.md`.
 
+> **GA BLOCKED pending `v1.0.0rc2` (recorded 2026-07-20):** a release-blocking
+> plot-plugin dispatch defect was found after RC1: the public factual,
+> alternative, and global/dashboard plotting APIs did not preserve the plugin
+> request end to end, forcing third-party visualization packages to
+> monkey-patch CE plotting callables. Under this plan's own emergency-patch
+> rule, the **"no planned implementation" posture now has exactly one
+> explicitly approved emergency compatibility exception**: the CE-native
+> third-party plot dispatch fix tracked in
+> `development/current-work/v1.0.0-rc2_plan.md`. Consequences:
+>
+> - **`v1.0.0rc2` — not `v1.0.0rc1` — becomes the final GA baseline.**
+> - Unaffected RC1 evidence (schema freeze, caching/parallel staging
+>   sign-off, deprecation closure, docstring coverage) carries forward.
+> - Plugin-dispatch evidence and the public API snapshots (additive
+>   `PlotRenderContext.runtime`, `PluginManager.resolve_plot_plugin_strict`)
+>   **must be revalidated** on the RC2 candidate before GA.
+> - `Development Status :: 5 - Production/Stable` promotion remains blocked
+>   until `v1.0.0rc2` is published and verified.
+
 > **GA posture:** v1.0.0 is a **stability-declaration milestone**, not an
 > implementation milestone. Every ADR and Standard in scope for v1.0.0 was
 > closed before or during the RC (see `RELEASE_PLAN_v1.md` §"ADR and

--- a/docs/contributor/plugin-contract.md
+++ b/docs/contributor/plugin-contract.md
@@ -519,7 +519,9 @@ denied (`CE_DENY_PLUGIN`), or incomplete. CE never silently substitutes
 `plot_spec.default`, `legacy`, or any fallback for an explicit request, and
 builder/renderer/validation errors surface without built-in fallback.
 Configured preferences (manager `plot_style`, `CE_PLOT_STYLE`,
-pyproject) keep their governed chain-with-visible-fallback semantics.
+pyproject) keep their governed chain-with-visible-fallback semantics. Passing
+`use_legacy=False` excludes the legacy renderer but does not disable a
+configured non-legacy third-party style.
 Contradictory explicit requests (for example `style="vendor.style"` together
 with `use_legacy=True`, or a differing string `style_override`) raise
 `ValidationError`.
@@ -530,9 +532,11 @@ plugin.render -> return result unchanged`. A renderer that returns `None` has
 still handled the request; CE never re-renders a built-in plot afterwards.
 
 **Transport fields.** `context.path` is `path=` if supplied, else `filename=`,
-else `None` — verbatim, with no `plots/` prefix, suffix rewriting, or
-directory creation (the renderer owns output formats). Supplying conflicting
-`path` and `filename` raises `ValidationError`. `context.show` defaults to
+else `None` — exact empty strings retain the historical no-save meaning;
+non-empty values are otherwise verbatim, with no `plots/` prefix, suffix
+rewriting, or directory creation (the renderer owns output formats).
+Supplying conflicting non-empty `path` and `filename` raises
+`ValidationError`. `context.show` defaults to
 `False` when an output path is present and `True` otherwise; an explicit
 `show=` always wins. `save_ext` is forwarded as given (lists become tuples);
 CE invents no default extensions for external renderers.
@@ -550,7 +554,10 @@ deep-copied.
 outputs once and publishes them under the reserved `context.options["payload"]`
 key (`proba`/`predict`/`low`/`high`/`uncertainty`/`y`/`is_regularized`/
 `threshold`/`class_labels`/`x`). A caller-supplied `payload=` kwarg raises
-`ValidationError` rather than being silently overwritten.
+`ValidationError` rather than being silently overwritten. For unthresholded
+regression, payload `low`/`high` values are computed with the caller's
+`low_high_percentiles` when supplied, so numerical bounds and forwarded
+metadata describe the same interval request.
 
 **Runtime context (trusted plugins only).** `context.runtime` is a read-only
 mapping of live references (never deep copies). For instance plots:

--- a/docs/contributor/plugin-contract.md
+++ b/docs/contributor/plugin-contract.md
@@ -501,6 +501,106 @@ Plot styles control visualization rendering:
 - **pyproject.toml**: Under `[tool.calibrated_explanations.plots]` with key `style`
 - **Dependencies**: Seeded from explanation plugin metadata `plot_dependency`
 
+### Third-party style dispatch contract (v1.0.0rc2)
+
+CE owns the style vocabulary `regular`, `triangular`, `ensured`, `narrative`,
+`legacy`, and `plot_spec.default`. Any other string passed as `style=` to
+`FactualExplanation.plot(...)`, `AlternativeExplanation.plot(...)`, or
+`CalibratedExplainer.plot(...)` (via `plotting.plot_global`) is an **explicit
+third-party style request** and dispatches through the registry *before* any
+built-in option consumption, feature ranking, identical-to-base filtering,
+`ensured`/`triangular` rewriting, or Matplotlib-oriented path handling.
+`FastExplanation.plot(...)` is out of scope: it documents only CE-owned styles
+and keeps its pre-1.0.0rc2 behavior.
+
+**Strict resolution.** An explicit style resolves to the exact registered
+identifier or raises `ConfigurationError` stating whether it was unregistered,
+denied (`CE_DENY_PLUGIN`), or incomplete. CE never silently substitutes
+`plot_spec.default`, `legacy`, or any fallback for an explicit request, and
+builder/renderer/validation errors surface without built-in fallback.
+Configured preferences (manager `plot_style`, `CE_PLOT_STYLE`,
+pyproject) keep their governed chain-with-visible-fallback semantics.
+Contradictory explicit requests (for example `style="vendor.style"` together
+with `use_legacy=True`, or a differing string `style_override`) raise
+`ValidationError`.
+
+**Dispatch sequence.** `resolve (strict) -> build context -> plugin.build ->
+validate PlotSpec-like artifacts (``validate_plot_artifact``) ->
+plugin.render -> return result unchanged`. A renderer that returns `None` has
+still handled the request; CE never re-renders a built-in plot afterwards.
+
+**Transport fields.** `context.path` is `path=` if supplied, else `filename=`,
+else `None` — verbatim, with no `plots/` prefix, suffix rewriting, or
+directory creation (the renderer owns output formats). Supplying conflicting
+`path` and `filename` raises `ValidationError`. `context.show` defaults to
+`False` when an output path is present and `True` otherwise; an explicit
+`show=` always wins. `save_ext` is forwarded as given (lists become tuples);
+CE invents no default extensions for external renderers.
+
+**`context.options`.** All caller kwargs that are not selection
+(`style`, `renderer`, `use_legacy`, string `style_override`) or transport
+(`show`, `path`, `filename`, `save_ext`) fields arrive untouched — including
+`filter_top` (always present, `None` when defaulted), `uncertainty`,
+`rnk_metric`, `rnk_weight`, `bins`, `low_high_percentiles`, and arbitrary
+nested plugin options. Option mappings are shallow-copied into a read-only
+mapping; caller dictionaries are never mutated and nested values are not
+deep-copied.
+
+**Global reserved payload.** For global/dashboard styles, CE validates model
+outputs once and publishes them under the reserved `context.options["payload"]`
+key (`proba`/`predict`/`low`/`high`/`uncertainty`/`y`/`is_regularized`/
+`threshold`/`class_labels`/`x`). A caller-supplied `payload=` kwarg raises
+`ValidationError` rather than being silently overwritten.
+
+**Runtime context (trusted plugins only).** `context.runtime` is a read-only
+mapping of live references (never deep copies). For instance plots:
+`{"scope": "instance", "explainer": <resolved public explainer snapshot>,
+"instance_index": explanation.index}`. For global/dashboard plots:
+`{"scope": "global", "explainer": explainer, "x": x, "y": y,
+"threshold": threshold, "bins": bins}`. It is populated **only** when both the
+builder and renderer passed the ADR-006 trust policy (`CE_TRUST_PLUGIN`,
+pyproject `[tool.calibrated_explanations.plugins].trusted`, or
+`mark_plot_builder_trusted`/`mark_plot_renderer_trusted`); untrusted plugins
+receive an empty mapping. Trusted visualization plugins execute arbitrary
+Python and can reach the model and input data through this runtime state —
+grant trust deliberately. Runtime state is process-local: pickling a
+`PlotRenderContext` drops it, and unpickling restores an empty read-only
+mapping.
+
+**Prohibition.** Plugins must not replace, wrap, or monkey-patch
+`FactualExplanation.plot`, `AlternativeExplanation.plot`,
+`plotting.plot_global`, or any other CE callable. The dispatch contract above
+makes such bridges unnecessary.
+
+Minimal factual example:
+
+```python
+factual = explainer.explain_factual(x_test)[0]
+result = factual.plot(
+    style="vendor.factual",       # exact registered style id
+    filter_top=5,                  # arrives in context.options unchanged
+    uncertainty=True,
+    vendor_options={"theme": "dark"},
+    show=False,
+)
+# result is whatever vendor.factual's renderer returned (None included).
+```
+
+Minimal global/dashboard example (trusted plugin):
+
+```python
+result = explainer.plot(
+    x_test,
+    y_test,
+    style="vendor.dashboard",
+    dashboard_options={"cards": ["overview"]},
+    show=False,
+)
+# The builder receives context.options["payload"] (validated predictions)
+# plus context.runtime["explainer"|"x"|"y"|"threshold"|"bins"] and may call
+# public explainer.explain_factual(...) / explore_alternatives(...) itself.
+```
+
 ---
 
 ## Wiring plugins into your explainer and explanations

--- a/scripts/local_checks.py
+++ b/scripts/local_checks.py
@@ -1302,7 +1302,9 @@ def _changed_paths_since(recorded_head_sha: str | None) -> set[str]:
     the ``HEAD`` recorded at preflight completion catches paths touched by
     any commit made since, in addition to whatever is still uncommitted.
     """
-    paths = set(_parse_git_status_paths(_git_text("status", "--porcelain", "--untracked-files=all") or ""))
+    paths = set(
+        _parse_git_status_paths(_git_text("status", "--porcelain", "--untracked-files=all") or "")
+    )
     current_head_sha = _git_text("rev-parse", "HEAD")
     if recorded_head_sha and current_head_sha and recorded_head_sha != current_head_sha:
         committed_diff = _git_text("diff", "--name-only", recorded_head_sha, current_head_sha) or ""

--- a/scripts/quality/snapshot_public_api.py
+++ b/scripts/quality/snapshot_public_api.py
@@ -60,7 +60,7 @@ def main():
     # unless explicitly re-exported by the root __init__.py.
 
     out_file = OUT_DIR / f"api_public_{ts}.txt"
-    out_file.write_text("\n".join(lines), encoding="utf-8")
+    out_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
     print(f"Wrote API snapshot to {out_file}")
 
 

--- a/scripts/tests/benchmarks/api_public_20260720_115705.txt
+++ b/scripts/tests/benchmarks/api_public_20260720_115705.txt
@@ -1,4 +1,4 @@
-# Public API snapshot for calibrated_explanations @ 20260715_134523 UTC
+# Public API snapshot for calibrated_explanations @ 20260720_115705 UTC
 # Root package exports:
 CalibratedExplainer
 ExplainerBuilder

--- a/src/calibrated_explanations/explanations/explanation.py
+++ b/src/calibrated_explanations/explanations/explanation.py
@@ -32,7 +32,14 @@ import numpy as np
 from pandas import Categorical
 
 from ..api.params import reject_unsupported_narrative_kwargs
-from ..plotting import plot_alternative, plot_probabilistic, plot_regression, plot_triangular
+from ..plotting import (
+    _dispatch_explicit_instance_plot_style,
+    _is_third_party_plot_style,
+    plot_alternative,
+    plot_probabilistic,
+    plot_regression,
+    plot_triangular,
+)
 from ..utils import (
     BinaryEntropyDiscretizer,
     BinaryRegressorDiscretizer,
@@ -2374,6 +2381,12 @@ class FactualExplanation(CalibratedExplanation):
               the ranking. Used with the 'ensured' ranking metric.
         """
         requested_style = kwargs.get("style")
+        # Third-party styles dispatch before any built-in option consumption,
+        # ranking, filtering, or transport rewriting (the plugin owns those).
+        if _is_third_party_plot_style(requested_style):
+            return _dispatch_explicit_instance_plot_style(
+                self, intent_type="factual", filter_top=filter_top, kwargs=kwargs
+            ).result
         custom_plot_style = isinstance(requested_style, str) and requested_style not in {
             "regular",
             "triangular",
@@ -3933,6 +3946,12 @@ class AlternativeExplanation(CalibratedExplanation):
                 The weight of the uncertainty in the ranking. Used with the 'ensured' ranking metric.
         """
         requested_style = kwargs.get("style")
+        # Third-party styles dispatch before built-in ranking, identical-to-base
+        # filtering, and ensured/triangular rewriting (the plugin owns those).
+        if _is_third_party_plot_style(requested_style):
+            return _dispatch_explicit_instance_plot_style(
+                self, intent_type="alternative", filter_top=filter_top, kwargs=kwargs
+            ).result
         custom_plot_style = isinstance(requested_style, str) and requested_style not in {
             "regular",
             "triangular",

--- a/src/calibrated_explanations/explanations/explanation.py
+++ b/src/calibrated_explanations/explanations/explanation.py
@@ -33,6 +33,8 @@ from pandas import Categorical
 
 from ..api.params import reject_unsupported_narrative_kwargs
 from ..plotting import (
+    _configured_dispatch_blocked,
+    _dispatch_configured_instance_plot_style,
     _dispatch_explicit_instance_plot_style,
     _is_third_party_plot_style,
     plot_alternative,
@@ -2380,13 +2382,32 @@ class FactualExplanation(CalibratedExplanation):
             - rnk_weight (float): default=0.5. The weight of the uncertainty in
               the ranking. Used with the 'ensured' ranking metric.
         """
-        requested_style = kwargs.get("style")
         # Third-party styles dispatch before any built-in option consumption,
         # ranking, filtering, or transport rewriting (the plugin owns those).
-        if _is_third_party_plot_style(requested_style):
+        # style_override is an equally valid selection surface (see
+        # _resolve_named_plot_style precedence), so it is checked alongside
+        # style, not only style.
+        requested_style = kwargs.get("style")
+        style_override_kwarg = kwargs.get("style_override")
+        effective_style = requested_style
+        if not _is_third_party_plot_style(effective_style) and _is_third_party_plot_style(
+            style_override_kwarg
+        ):
+            effective_style = style_override_kwarg
+        if _is_third_party_plot_style(effective_style):
             return _dispatch_explicit_instance_plot_style(
-                self, intent_type="factual", filter_top=filter_top, kwargs=kwargs
+                self,
+                intent_type="factual",
+                filter_top=filter_top,
+                style=effective_style,
+                kwargs=kwargs,
             ).result
+        if not _configured_dispatch_blocked(kwargs):
+            configured_outcome = _dispatch_configured_instance_plot_style(
+                self, intent_type="factual", filter_top=filter_top, kwargs=kwargs
+            )
+            if configured_outcome is not None:
+                return configured_outcome.result
         custom_plot_style = isinstance(requested_style, str) and requested_style not in {
             "regular",
             "triangular",
@@ -3945,13 +3966,31 @@ class AlternativeExplanation(CalibratedExplanation):
             rnk_weight : float, default=0.5
                 The weight of the uncertainty in the ranking. Used with the 'ensured' ranking metric.
         """
-        requested_style = kwargs.get("style")
         # Third-party styles dispatch before built-in ranking, identical-to-base
         # filtering, and ensured/triangular rewriting (the plugin owns those).
-        if _is_third_party_plot_style(requested_style):
+        # style_override is an equally valid selection surface, so it is
+        # checked alongside style, not only style.
+        requested_style = kwargs.get("style")
+        style_override_kwarg = kwargs.get("style_override")
+        effective_style = requested_style
+        if not _is_third_party_plot_style(effective_style) and _is_third_party_plot_style(
+            style_override_kwarg
+        ):
+            effective_style = style_override_kwarg
+        if _is_third_party_plot_style(effective_style):
             return _dispatch_explicit_instance_plot_style(
-                self, intent_type="alternative", filter_top=filter_top, kwargs=kwargs
+                self,
+                intent_type="alternative",
+                filter_top=filter_top,
+                style=effective_style,
+                kwargs=kwargs,
             ).result
+        if not _configured_dispatch_blocked(kwargs):
+            configured_outcome = _dispatch_configured_instance_plot_style(
+                self, intent_type="alternative", filter_top=filter_top, kwargs=kwargs
+            )
+            if configured_outcome is not None:
+                return configured_outcome.result
         custom_plot_style = isinstance(requested_style, str) and requested_style not in {
             "regular",
             "triangular",

--- a/src/calibrated_explanations/plotting.py
+++ b/src/calibrated_explanations/plotting.py
@@ -13,6 +13,7 @@ import logging
 import os
 import sys
 import warnings
+from dataclasses import dataclass
 from pathlib import Path, PurePath
 from types import MappingProxyType
 from typing import Any, Dict, List, Mapping, Sequence
@@ -480,6 +481,198 @@ def _render_collection_plot_plugin(
     artifact = plugin.build(context)
     validate_plot_artifact(artifact, identifier=identifier)
     return plugin.render(artifact, context=context)
+
+
+# CE-owned style vocabulary: explanation-level semantic names plus the two
+# registered built-in style identifiers. Any other explicit style string is a
+# third-party plugin request and takes the strict dispatch path below.
+_CE_OWNED_PLOT_STYLES = _BUILTIN_INSTANCE_PLOT_STYLES | {"legacy", "plot_spec.default"}
+
+# Keys consumed by CE for route selection or output transport; everything else
+# in the caller's kwargs is plugin-owned and forwarded untouched.
+_THIRD_PARTY_SELECTION_KEYS = frozenset({"style", "renderer", "use_legacy"})
+_THIRD_PARTY_TRANSPORT_KEYS = frozenset({"show", "path", "filename", "save_ext"})
+
+# Reserved key under which plot_global exposes CE's validated prediction
+# payload to global/dashboard plugins.
+_GLOBAL_PAYLOAD_KEY = "payload"
+
+
+@dataclass(frozen=True)
+class _PlotDispatchOutcome:
+    """Result of a third-party plot dispatch.
+
+    ``handled`` is deliberately distinct from ``result is not None``: a
+    renderer that successfully handles a request may legitimately return
+    ``None``, and that must not re-trigger built-in rendering.
+    """
+
+    handled: bool
+    result: Any = None
+
+
+def _is_third_party_plot_style(style: Any) -> bool:
+    """Return True when *style* explicitly requests a non-CE-owned plot style."""
+    return isinstance(style, str) and bool(style) and style not in _CE_OWNED_PLOT_STYLES
+
+
+def _reject_conflicting_plot_selection(style: str, kwargs: Mapping[str, Any]) -> None:
+    """Raise ValidationError for contradictory explicit plot requests."""
+    from .utils.exceptions import ValidationError  # pylint: disable=import-outside-toplevel
+
+    if kwargs.get("use_legacy"):
+        raise ValidationError(
+            f"Contradictory plot request: style='{style}' selects a third-party "
+            "plot plugin but use_legacy=True selects the built-in legacy "
+            "renderer. Remove one of the two."
+        )
+    style_override = kwargs.get("style_override")
+    if isinstance(style_override, str) and style_override and style_override != style:
+        raise ValidationError(
+            f"Contradictory plot request: style='{style}' and "
+            f"style_override='{style_override}' name different styles. "
+            "Remove one of the two."
+        )
+
+
+def _normalize_third_party_transport(kwargs: Mapping[str, Any]) -> tuple[bool, Any, Any]:
+    """Return ``(show, path, save_ext)`` for a third-party plot request.
+
+    The renderer owns output formats: the path is taken verbatim from ``path``
+    (or ``filename`` as its alias) with no directory prefix, suffix rewrite,
+    or Matplotlib-oriented splitting.
+    """
+    from .utils.exceptions import ValidationError  # pylint: disable=import-outside-toplevel
+
+    path = kwargs.get("path")
+    filename = kwargs.get("filename")
+    if path is not None and filename is not None and path != filename:
+        raise ValidationError(
+            "Conflicting output arguments: path="
+            f"{path!r} and filename={filename!r} differ. Provide only one "
+            "output location for a third-party plot style."
+        )
+    effective_path = path if path is not None else filename
+    show = kwargs.get("show", effective_path is None)
+    save_ext = kwargs.get("save_ext")
+    if isinstance(save_ext, list):
+        save_ext = tuple(save_ext)
+    return show, effective_path, save_ext
+
+
+def _third_party_plot_options(kwargs: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract plugin-owned options from *kwargs* without mutating the caller's mapping."""
+    excluded = _THIRD_PARTY_SELECTION_KEYS | _THIRD_PARTY_TRANSPORT_KEYS
+    options: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if key in excluded:
+            continue
+        if key == "style_override" and (value is None or isinstance(value, str)):
+            # A string style_override is a selection surface (already validated
+            # against the explicit style) and None is its absent default;
+            # mapping-valued overrides remain plugin-visible configuration.
+            continue
+        options[key] = value
+    return options
+
+
+def _dispatch_third_party_plot(
+    *,
+    explainer: Any,
+    explanation: Any,
+    intent_type: str,
+    instance_metadata: Mapping[str, Any],
+    style: str,
+    renderer_override: str | None,
+    show: Any,
+    path: Any,
+    save_ext: Any,
+    options: Mapping[str, Any],
+    runtime: Mapping[str, Any],
+) -> _PlotDispatchOutcome:
+    """Resolve *style* strictly and run build -> validate -> render.
+
+    Errors from resolution, the builder, artifact validation, or the renderer
+    surface to the caller: an explicitly requested third-party style never
+    falls back to built-in rendering.
+    """
+    from .plugins import PlotRenderContext, ensure_builtin_plugins
+    from .utils.exceptions import ConfigurationError
+
+    ensure_builtin_plugins()
+    manager = getattr(explainer, "plugin_manager", None)
+    resolver = getattr(manager, "resolve_plot_plugin_strict", None)
+    if not callable(resolver):
+        raise ConfigurationError(
+            f"Cannot resolve plot style '{style}': no plugin manager with "
+            "strict plot-style resolution is reachable from this explanation. "
+            "Third-party styles require an explainer created through the "
+            "public CalibratedExplainer/WrapCalibratedExplainer API."
+        )
+    plugin, identifier, trusted = resolver(style, renderer_override=renderer_override)
+
+    context = PlotRenderContext(
+        explanation=explanation,
+        instance_metadata=MappingProxyType(dict(instance_metadata)),
+        style=identifier,
+        intent=MappingProxyType(
+            {
+                "type": intent_type,
+                "explainer_mode": getattr(explainer, "_last_explanation_mode", None),
+            }
+        ),
+        show=show,
+        path=path,
+        save_ext=save_ext,
+        options=MappingProxyType(dict(options)),
+        plugin_config=_bind_plot_plugin_config(manager, identifier, plugin),
+        # ADR-006: live runtime references (explainer, request data) are
+        # granted to trusted plugins only.
+        runtime=runtime if trusted else {},
+    )
+    artifact = plugin.build(context)
+    validate_plot_artifact(artifact, identifier=identifier)
+    result = plugin.render(artifact, context=context)
+    return _PlotDispatchOutcome(handled=True, result=result)
+
+
+def _dispatch_explicit_instance_plot_style(
+    explanation: Any,
+    *,
+    intent_type: str,
+    filter_top: Any,
+    kwargs: Mapping[str, Any],
+) -> _PlotDispatchOutcome:
+    """Dispatch an explanation-level third-party plot request before any
+    built-in ranking, filtering, or transport rewriting can consume it."""
+    style = kwargs.get("style")
+    _reject_conflicting_plot_selection(style, kwargs)
+    show, path, save_ext = _normalize_third_party_transport(kwargs)
+    options = _third_party_plot_options(kwargs)
+    # filter_top is positional in explanation.plot; always forward it,
+    # including its default None, so plugins see the complete request.
+    options["filter_top"] = filter_top
+
+    explainer = _resolve_explainer_from_explanation(explanation)
+    instance_index = getattr(explanation, "index", None)
+    runtime = {
+        "scope": "instance",
+        "explainer": explainer,
+        "instance_index": instance_index,
+    }
+    return _dispatch_third_party_plot(
+        explainer=explainer,
+        explanation=explanation,
+        intent_type=intent_type,
+        instance_metadata={"type": "instance", "index": instance_index},
+        style=style,
+        renderer_override=kwargs.get("renderer"),
+        show=show,
+        path=path,
+        save_ext=save_ext,
+        options=options,
+        runtime=runtime,
+    )
 
 
 def _plugin_instance_index(explanation: Any, options: Mapping[str, Any]) -> Any:
@@ -1792,6 +1985,82 @@ def plot_alternative(
 
 
 # pylint: disable=duplicate-code, too-many-branches, too-many-statements, too-many-locals
+def _dispatch_explicit_global_plot_style(
+    explainer: Any,
+    x: Any,
+    y: Any,
+    threshold: Any,
+    style: str,
+    kwargs: Mapping[str, Any],
+) -> _PlotDispatchOutcome:
+    """Dispatch an explicit third-party global/dashboard style from plot_global."""
+    from .utils.exceptions import ValidationError  # pylint: disable=import-outside-toplevel
+
+    _reject_conflicting_plot_selection(style, kwargs)
+    if _GLOBAL_PAYLOAD_KEY in kwargs:
+        raise ValidationError(
+            f"'{_GLOBAL_PAYLOAD_KEY}' is a reserved plot_global option: CE "
+            "publishes its validated global prediction payload under this key "
+            "and will not overwrite or forward a caller-supplied value. Rename "
+            "the argument."
+        )
+    show, path, save_ext = _normalize_third_party_transport(kwargs)
+    bins = kwargs.get("bins")
+
+    # CE-owned validation of model outputs happens before dispatch so every
+    # global renderer observes the same validated prediction payload.
+    is_regularized = True
+    if "predict_proba" not in dir(explainer.learner) and threshold is None:
+        predict, (low, high) = explainer.predict(x, uq_interval=True, bins=bins)
+        proba = None
+        is_regularized = False
+    else:
+        proba, (low, high) = explainer.predict_proba(
+            x, uq_interval=True, threshold=threshold, bins=bins
+        )
+        predict = None
+    uncertainty = (
+        (np.array(high) - np.array(low)) if (low is not None and high is not None) else None
+    )
+    payload = {
+        "proba": proba,
+        "predict": predict,
+        "low": low,
+        "high": high,
+        "uncertainty": uncertainty,
+        "y": (list(y) if y is not None else None),
+        "is_regularized": is_regularized,
+        "threshold": threshold,
+        "class_labels": getattr(explainer, "class_labels", None),
+        "x": x,
+    }
+
+    options = _third_party_plot_options(kwargs)
+    options[_GLOBAL_PAYLOAD_KEY] = payload
+
+    runtime = {
+        "scope": "global",
+        "explainer": explainer,
+        "x": x,
+        "y": y,
+        "threshold": threshold,
+        "bins": bins,
+    }
+    return _dispatch_third_party_plot(
+        explainer=explainer,
+        explanation=getattr(explainer, "latest_explanation", None),
+        intent_type="global",
+        instance_metadata={"type": "global"},
+        style=style,
+        renderer_override=kwargs.get("renderer"),
+        show=show,
+        path=path,
+        save_ext=save_ext,
+        options=options,
+        runtime=runtime,
+    )
+
+
 def plot_global(explainer, x, y=None, threshold=None, **kwargs):
     """
     Generate a global explanation plot for the given test data.
@@ -1814,6 +2083,16 @@ def plot_global(explainer, x, y=None, threshold=None, **kwargs):
     **kwargs : dict
         Additional keyword arguments.
     """
+    requested_style = kwargs.get("style")
+    if not _is_third_party_plot_style(requested_style):
+        style_override_value = kwargs.get("style_override")
+        if _is_third_party_plot_style(style_override_value):
+            requested_style = style_override_value
+    if _is_third_party_plot_style(requested_style):
+        return _dispatch_explicit_global_plot_style(
+            explainer, x, y, threshold, requested_style, kwargs
+        ).result
+
     _reject_unconsumed_plot_kwargs("plot_global", kwargs, allowed=_PLOT_GLOBAL_KWARGS)
 
     show = kwargs.get("show", True)

--- a/src/calibrated_explanations/plotting.py
+++ b/src/calibrated_explanations/plotting.py
@@ -630,11 +630,12 @@ def _dispatch_explicit_instance_plot_style(
     kwargs: Mapping[str, Any],
     resolved: tuple[Any, str, bool] | None = None,
 ) -> _PlotDispatchOutcome:
-    """Dispatch an explanation-level third-party plot request before any
-    built-in ranking, filtering, or transport rewriting can consume it.
+    """Dispatch an explanation-level third-party plot request before consumption.
 
-    *style* is the already-determined effective style identifier (from
-    ``style=``, ``style_override=``, or a resolved configured preference);
+    This runs before any built-in ranking, filtering, or transport rewriting
+    can consume the request. *style* is the already-determined effective
+    style identifier (from ``style=``, ``style_override=``, or a resolved
+    configured preference);
     callers must not re-derive it from ``kwargs["style"]`` alone, since an
     explicit ``style_override=`` can name the plugin instead.
     """
@@ -754,7 +755,7 @@ def _dispatch_configured_instance_plot_style(
         return None
     try:
         resolved = resolver(configured_style, renderer_override=kwargs.get("renderer"))
-    except Exception:  # noqa: BLE001 - unresolved configured style defers to built-in fallback
+    except Exception:  # noqa: BLE001 - adr002_allow: unresolved configured style defers to built-in fallback
         return None
     return _dispatch_explicit_instance_plot_style(
         explanation,
@@ -2200,7 +2201,7 @@ def _dispatch_configured_global_plot_style(
         return None
     try:
         resolved = resolver(configured_style, renderer_override=kwargs.get("renderer"))
-    except Exception:  # noqa: BLE001 - unresolved configured style defers to legacy fallback
+    except Exception:  # noqa: BLE001 - adr002_allow: unresolved configured style defers to legacy fallback
         return None
     try:
         return _dispatch_explicit_global_plot_style(
@@ -2208,7 +2209,7 @@ def _dispatch_configured_global_plot_style(
         )
     except ValidationError:
         raise
-    except Exception as exc:  # noqa: BLE001 - matches plot_global's existing catch-and-fallback
+    except Exception as exc:  # noqa: BLE001 - adr002_allow: matches plot_global's existing catch-and-fallback
         _warn_and_log_plotspec_fallback(
             f"PlotSpec rendering failed with '{exc}'. Falling back to legacy plot."
         )

--- a/src/calibrated_explanations/plotting.py
+++ b/src/calibrated_explanations/plotting.py
@@ -523,8 +523,8 @@ def _normalize_third_party_transport(kwargs: Mapping[str, Any]) -> tuple[bool, A
     """
     from .utils.exceptions import ValidationError  # pylint: disable=import-outside-toplevel
 
-    path = kwargs.get("path")
-    filename = kwargs.get("filename")
+    path = None if kwargs.get("path") == "" else kwargs.get("path")
+    filename = None if kwargs.get("filename") == "" else kwargs.get("filename")
     if path is not None and filename is not None and path != filename:
         raise ValidationError(
             "Conflicting output arguments: path="
@@ -674,8 +674,8 @@ def _configured_dispatch_blocked(kwargs: Mapping[str, Any]) -> bool:
     Mirrors the exact reachability condition of ``_select_default_plot_style``
     in the built-in dispatch path: configured (manager/env/pyproject/chain)
     style preference is consulted only when the caller supplied none of
-    ``style``, a string ``style_override``, ``use_legacy`` (True or False),
-    or a truthy ``return_plot_spec``. Any of those present must retain their
+    ``style``, a string ``style_override``, ``use_legacy=True``, or a truthy
+    ``return_plot_spec``. Any of those present must retain their
     existing precedence over ambient configuration -- this guard exists
     purely to avoid changing *when* configured resolution is reached, not to
     change what it resolves to.
@@ -684,7 +684,7 @@ def _configured_dispatch_blocked(kwargs: Mapping[str, Any]) -> bool:
         return True
     if kwargs.get("return_plot_spec"):
         return True
-    if kwargs.get("use_legacy") is not None:
+    if kwargs.get("use_legacy") is True:
         return True
     style_override = kwargs.get("style_override")
     return isinstance(style_override, str) and bool(style_override)
@@ -978,7 +978,7 @@ def plot_probabilistic(
     if use_legacy is None:
         selected_style, use_legacy = _select_default_plot_style(explanation, explicit_style)
     else:
-        selected_style = explicit_style
+        selected_style = explicit_style or ("plot_spec.default" if use_legacy is False else None)
     explainer = _resolve_explainer_from_explanation(explanation)
 
     predict_payload = dict(predict or {})
@@ -1297,7 +1297,7 @@ def plot_regression(
     if use_legacy is None:
         selected_style, use_legacy = _select_default_plot_style(explanation, explicit_style)
     else:
-        selected_style = explicit_style
+        selected_style = explicit_style or ("plot_spec.default" if use_legacy is False else None)
 
     if use_legacy:
         from .viz import _matplotlib_compat as legacy
@@ -1618,7 +1618,7 @@ def plot_alternative(
     if use_legacy is None:
         selected_style, use_legacy = _select_default_plot_style(explanation, explicit_style)
     else:
-        selected_style = explicit_style
+        selected_style = explicit_style or ("plot_spec.default" if use_legacy is False else None)
     explainer = _resolve_explainer_from_explanation(explanation)
 
     if use_legacy:
@@ -2075,6 +2075,46 @@ def plot_alternative(
         return
 
 
+def _build_global_prediction_payload(
+    explainer: Any,
+    x: Any,
+    y: Any,
+    threshold: Any,
+    kwargs: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the validated prediction payload shared by all global plot routes."""
+    bins = kwargs.get("bins")
+    is_regularized = True
+    if "predict_proba" not in dir(explainer.learner) and threshold is None:
+        prediction_kwargs = {"bins": bins}
+        if "low_high_percentiles" in kwargs:
+            prediction_kwargs["low_high_percentiles"] = kwargs["low_high_percentiles"]
+        predict, (low, high) = explainer.predict(x, uq_interval=True, **prediction_kwargs)
+        proba = None
+        is_regularized = False
+    else:
+        proba, (low, high) = explainer.predict_proba(
+            x, uq_interval=True, threshold=threshold, bins=bins
+        )
+        predict = None
+
+    uncertainty = (
+        (np.array(high) - np.array(low)) if (low is not None and high is not None) else None
+    )
+    return {
+        "proba": proba,
+        "predict": predict,
+        "low": low,
+        "high": high,
+        "uncertainty": uncertainty,
+        "y": (list(y) if y is not None else None),
+        "is_regularized": is_regularized,
+        "threshold": threshold,
+        "class_labels": getattr(explainer, "class_labels", None),
+        "x": x,
+    }
+
+
 # pylint: disable=duplicate-code, too-many-branches, too-many-statements, too-many-locals
 def _dispatch_explicit_global_plot_style(
     explainer: Any,
@@ -2101,31 +2141,7 @@ def _dispatch_explicit_global_plot_style(
 
     # CE-owned validation of model outputs happens before dispatch so every
     # global renderer observes the same validated prediction payload.
-    is_regularized = True
-    if "predict_proba" not in dir(explainer.learner) and threshold is None:
-        predict, (low, high) = explainer.predict(x, uq_interval=True, bins=bins)
-        proba = None
-        is_regularized = False
-    else:
-        proba, (low, high) = explainer.predict_proba(
-            x, uq_interval=True, threshold=threshold, bins=bins
-        )
-        predict = None
-    uncertainty = (
-        (np.array(high) - np.array(low)) if (low is not None and high is not None) else None
-    )
-    payload = {
-        "proba": proba,
-        "predict": predict,
-        "low": low,
-        "high": high,
-        "uncertainty": uncertainty,
-        "y": (list(y) if y is not None else None),
-        "is_regularized": is_regularized,
-        "threshold": threshold,
-        "class_labels": getattr(explainer, "class_labels", None),
-        "x": x,
-    }
+    payload = _build_global_prediction_payload(explainer, x, y, threshold, kwargs)
 
     options = _third_party_plot_options(kwargs)
     options[_GLOBAL_PAYLOAD_KEY] = payload
@@ -2242,7 +2258,6 @@ def plot_global(explainer, x, y=None, threshold=None, **kwargs):
     _reject_unconsumed_plot_kwargs("plot_global", kwargs, allowed=_PLOT_GLOBAL_KWARGS)
 
     show = kwargs.get("show", True)
-    bins = kwargs.get("bins")
     use_legacy = kwargs.get("use_legacy")
     explicit_style = _resolve_named_plot_style(
         style_override=kwargs.get("style_override"),
@@ -2251,7 +2266,7 @@ def plot_global(explainer, x, y=None, threshold=None, **kwargs):
     if use_legacy is None:
         selected_style, use_legacy = _select_default_plot_style(explainer, explicit_style)
     else:
-        selected_style = explicit_style
+        selected_style = explicit_style or ("plot_spec.default" if use_legacy is False else None)
 
     # pre-v4 S4-H6: gather and validate model outputs once, ahead of the
     # use_legacy dispatch, so both the legacy and PlotSpec renderers observe
@@ -2260,16 +2275,12 @@ def plot_global(explainer, x, y=None, threshold=None, **kwargs):
     # which itself validated only after a "not show and no matplotlib"
     # no-op check -- so plot(..., threshold=<invalid>, use_legacy=True,
     # show=False) silently skipped validation entirely.
-    is_regularized = True
-    if "predict_proba" not in dir(explainer.learner) and threshold is None:
-        predict, (low, high) = explainer.predict(x, uq_interval=True, bins=bins)
-        proba = None
-        is_regularized = False
-    else:
-        proba, (low, high) = explainer.predict_proba(
-            x, uq_interval=True, threshold=threshold, bins=bins
-        )
-        predict = None
+    payload = _build_global_prediction_payload(explainer, x, y, threshold, kwargs)
+    proba = payload["proba"]
+    predict = payload["predict"]
+    low = payload["low"]
+    high = payload["high"]
+    is_regularized = payload["is_regularized"]
 
     validated_payload = {
         "proba": proba,
@@ -2291,23 +2302,6 @@ def plot_global(explainer, x, y=None, threshold=None, **kwargs):
     save_ext_value = kwargs.get("save_ext")
     if isinstance(save_ext_value, (list, tuple)):
         save_ext_value = tuple(save_ext_value)
-
-    uncertainty = (
-        (np.array(high) - np.array(low)) if (low is not None and high is not None) else None
-    )
-
-    payload = {
-        "proba": proba,
-        "predict": predict,
-        "low": low,
-        "high": high,
-        "uncertainty": uncertainty,
-        "y": (list(y) if y is not None else None),
-        "is_regularized": is_regularized,
-        "threshold": threshold,
-        "class_labels": getattr(explainer, "class_labels", None),
-        "x": x,
-    }
 
     from .plugins import (
         PlotRenderContext,

--- a/src/calibrated_explanations/plotting.py
+++ b/src/calibrated_explanations/plotting.py
@@ -273,30 +273,9 @@ def _select_default_plot_style(
         return explicit_style, False
 
     explainer = _resolve_explainer_from_explanation(explanation)
-    manager = getattr(explainer, "plugin_manager", None)
-    manager_style = getattr(manager, "plot_style_override", None)
-    if isinstance(manager_style, str) and manager_style:
-        return manager_style, manager_style == "legacy"
-
-    config_manager = _get_plotting_config_manager()
-    env_style = config_manager.env("CE_PLOT_STYLE")
-    if isinstance(env_style, str) and env_style.strip():
-        env_style = env_style.strip()
-        return env_style, env_style == "legacy"
-
-    py_settings = _read_plot_pyproject()
-    py_style = py_settings.get("style")
-    if isinstance(py_style, str) and py_style:
-        return py_style, py_style == "legacy"
-
-    chain = (
-        _resolve_plot_style_chain(explainer, explicit_style)
-        if explainer is not None
-        else ("plot_spec.default", "legacy")
-    )
-    for identifier in chain:
-        if identifier and identifier != "legacy":
-            return identifier, False
+    configured_style = _effective_configured_plot_style(explainer)
+    if configured_style:
+        return configured_style, configured_style == "legacy"
     return "plot_spec.default", False
 
 
@@ -589,27 +568,33 @@ def _dispatch_third_party_plot(
     save_ext: Any,
     options: Mapping[str, Any],
     runtime: Mapping[str, Any],
+    resolved: tuple[Any, str, bool] | None = None,
 ) -> _PlotDispatchOutcome:
     """Resolve *style* strictly and run build -> validate -> render.
 
     Errors from resolution, the builder, artifact validation, or the renderer
     surface to the caller: an explicitly requested third-party style never
-    falls back to built-in rendering.
+    falls back to built-in rendering. Pass *resolved* (from a prior
+    ``resolve_plot_plugin_strict`` call) to reuse an already-resolved
+    plugin/identifier/trust tuple instead of resolving again.
     """
     from .plugins import PlotRenderContext, ensure_builtin_plugins
     from .utils.exceptions import ConfigurationError
 
     ensure_builtin_plugins()
     manager = getattr(explainer, "plugin_manager", None)
-    resolver = getattr(manager, "resolve_plot_plugin_strict", None)
-    if not callable(resolver):
-        raise ConfigurationError(
-            f"Cannot resolve plot style '{style}': no plugin manager with "
-            "strict plot-style resolution is reachable from this explanation. "
-            "Third-party styles require an explainer created through the "
-            "public CalibratedExplainer/WrapCalibratedExplainer API."
-        )
-    plugin, identifier, trusted = resolver(style, renderer_override=renderer_override)
+    if resolved is not None:
+        plugin, identifier, trusted = resolved
+    else:
+        resolver = getattr(manager, "resolve_plot_plugin_strict", None)
+        if not callable(resolver):
+            raise ConfigurationError(
+                f"Cannot resolve plot style '{style}': no plugin manager with "
+                "strict plot-style resolution is reachable from this explanation. "
+                "Third-party styles require an explainer created through the "
+                "public CalibratedExplainer/WrapCalibratedExplainer API."
+            )
+        plugin, identifier, trusted = resolver(style, renderer_override=renderer_override)
 
     context = PlotRenderContext(
         explanation=explanation,
@@ -641,11 +626,18 @@ def _dispatch_explicit_instance_plot_style(
     *,
     intent_type: str,
     filter_top: Any,
+    style: str,
     kwargs: Mapping[str, Any],
+    resolved: tuple[Any, str, bool] | None = None,
 ) -> _PlotDispatchOutcome:
     """Dispatch an explanation-level third-party plot request before any
-    built-in ranking, filtering, or transport rewriting can consume it."""
-    style = kwargs.get("style")
+    built-in ranking, filtering, or transport rewriting can consume it.
+
+    *style* is the already-determined effective style identifier (from
+    ``style=``, ``style_override=``, or a resolved configured preference);
+    callers must not re-derive it from ``kwargs["style"]`` alone, since an
+    explicit ``style_override=`` can name the plugin instead.
+    """
     _reject_conflicting_plot_selection(style, kwargs)
     show, path, save_ext = _normalize_third_party_transport(kwargs)
     options = _third_party_plot_options(kwargs)
@@ -672,6 +664,105 @@ def _dispatch_explicit_instance_plot_style(
         save_ext=save_ext,
         options=options,
         runtime=runtime,
+        resolved=resolved,
+    )
+
+
+def _configured_dispatch_blocked(kwargs: Mapping[str, Any]) -> bool:
+    """Return True when *kwargs* already make an explicit selection.
+
+    Mirrors the exact reachability condition of ``_select_default_plot_style``
+    in the built-in dispatch path: configured (manager/env/pyproject/chain)
+    style preference is consulted only when the caller supplied none of
+    ``style``, a string ``style_override``, ``use_legacy`` (True or False),
+    or a truthy ``return_plot_spec``. Any of those present must retain their
+    existing precedence over ambient configuration -- this guard exists
+    purely to avoid changing *when* configured resolution is reached, not to
+    change what it resolves to.
+    """
+    if kwargs.get("style"):
+        return True
+    if kwargs.get("return_plot_spec"):
+        return True
+    if kwargs.get("use_legacy") is not None:
+        return True
+    style_override = kwargs.get("style_override")
+    return isinstance(style_override, str) and bool(style_override)
+
+
+def _effective_configured_plot_style(explainer: Any) -> str | None:
+    """Return the style CE would select via configured preference alone.
+
+    Mirrors the non-explicit branch of ``_select_default_plot_style``
+    (manager override -> ``CE_PLOT_STYLE`` -> pyproject -> first non-legacy
+    chain entry), used both by that function and by the configured-dispatch
+    helpers below so the two stay in lockstep.
+    """
+    manager = getattr(explainer, "plugin_manager", None)
+    manager_style = getattr(manager, "plot_style_override", None)
+    if isinstance(manager_style, str) and manager_style:
+        return manager_style
+
+    config_manager = _get_plotting_config_manager()
+    env_style = config_manager.env("CE_PLOT_STYLE")
+    if isinstance(env_style, str) and env_style.strip():
+        return env_style.strip()
+
+    py_settings = _read_plot_pyproject()
+    py_style = py_settings.get("style")
+    if isinstance(py_style, str) and py_style:
+        return py_style
+
+    chain = (
+        _resolve_plot_style_chain(explainer, None)
+        if explainer is not None
+        else ("plot_spec.default", "legacy")
+    )
+    for identifier in chain:
+        if identifier and identifier != "legacy":
+            return identifier
+    return None
+
+
+def _dispatch_configured_instance_plot_style(
+    explanation: Any,
+    *,
+    intent_type: str,
+    filter_top: Any,
+    kwargs: Mapping[str, Any],
+) -> _PlotDispatchOutcome | None:
+    """Attempt full-fidelity dispatch for a *configured* (non-explicit) style.
+
+    Returns ``None`` when the configured preference is CE-owned or does not
+    resolve to a registered plugin, so the caller falls through to the
+    existing built-in/chain-based path unchanged -- preserving the
+    ADR-approved configured-preference fallback behavior exactly. Unlike the
+    explicit path, this never raises for resolution failure: only an
+    explicit ``style=``/``style_override=`` request is strict.
+    """
+    if _configured_dispatch_blocked(kwargs):
+        return None
+    explainer = _resolve_explainer_from_explanation(explanation)
+    if explainer is None:
+        return None
+    configured_style = _effective_configured_plot_style(explainer)
+    if not _is_third_party_plot_style(configured_style):
+        return None
+    manager = getattr(explainer, "plugin_manager", None)
+    resolver = getattr(manager, "resolve_plot_plugin_strict", None)
+    if not callable(resolver):
+        return None
+    try:
+        resolved = resolver(configured_style, renderer_override=kwargs.get("renderer"))
+    except Exception:  # noqa: BLE001 - unresolved configured style defers to built-in fallback
+        return None
+    return _dispatch_explicit_instance_plot_style(
+        explanation,
+        intent_type=intent_type,
+        filter_top=filter_top,
+        style=configured_style,
+        kwargs=kwargs,
+        resolved=resolved,
     )
 
 
@@ -1992,6 +2083,7 @@ def _dispatch_explicit_global_plot_style(
     threshold: Any,
     style: str,
     kwargs: Mapping[str, Any],
+    resolved: tuple[Any, str, bool] | None = None,
 ) -> _PlotDispatchOutcome:
     """Dispatch an explicit third-party global/dashboard style from plot_global."""
     from .utils.exceptions import ValidationError  # pylint: disable=import-outside-toplevel
@@ -2058,7 +2150,53 @@ def _dispatch_explicit_global_plot_style(
         save_ext=save_ext,
         options=options,
         runtime=runtime,
+        resolved=resolved,
     )
+
+
+def _dispatch_configured_global_plot_style(
+    explainer: Any,
+    x: Any,
+    y: Any,
+    threshold: Any,
+    kwargs: Mapping[str, Any],
+) -> _PlotDispatchOutcome | None:
+    """Attempt full-fidelity dispatch for a *configured* (non-explicit) global style.
+
+    Returns ``None`` when the configured preference is CE-owned, does not
+    resolve to a registered plugin, or fails during build/render -- in all
+    three cases the caller falls through to the existing legacy-fallback
+    path, preserving ``plot_global``'s pre-existing visible-fallback
+    governance for configured (not explicit) selections. A malformed request
+    (conflicting transport, reserved ``payload`` key) still raises, since
+    that is a caller bug rather than a plugin-availability issue.
+    """
+    from .utils.exceptions import ValidationError  # pylint: disable=import-outside-toplevel
+
+    if _configured_dispatch_blocked(kwargs):
+        return None
+    configured_style = _effective_configured_plot_style(explainer)
+    if not _is_third_party_plot_style(configured_style):
+        return None
+    manager = getattr(explainer, "plugin_manager", None)
+    resolver = getattr(manager, "resolve_plot_plugin_strict", None)
+    if not callable(resolver):
+        return None
+    try:
+        resolved = resolver(configured_style, renderer_override=kwargs.get("renderer"))
+    except Exception:  # noqa: BLE001 - unresolved configured style defers to legacy fallback
+        return None
+    try:
+        return _dispatch_explicit_global_plot_style(
+            explainer, x, y, threshold, configured_style, kwargs, resolved=resolved
+        )
+    except ValidationError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - matches plot_global's existing catch-and-fallback
+        _warn_and_log_plotspec_fallback(
+            f"PlotSpec rendering failed with '{exc}'. Falling back to legacy plot."
+        )
+        return None
 
 
 def plot_global(explainer, x, y=None, threshold=None, **kwargs):
@@ -2083,15 +2221,23 @@ def plot_global(explainer, x, y=None, threshold=None, **kwargs):
     **kwargs : dict
         Additional keyword arguments.
     """
-    requested_style = kwargs.get("style")
-    if not _is_third_party_plot_style(requested_style):
-        style_override_value = kwargs.get("style_override")
-        if _is_third_party_plot_style(style_override_value):
-            requested_style = style_override_value
+    style_kwarg = kwargs.get("style")
+    style_override_kwarg = kwargs.get("style_override")
+    requested_style = style_kwarg
+    if not _is_third_party_plot_style(requested_style) and _is_third_party_plot_style(
+        style_override_kwarg
+    ):
+        requested_style = style_override_kwarg
     if _is_third_party_plot_style(requested_style):
         return _dispatch_explicit_global_plot_style(
             explainer, x, y, threshold, requested_style, kwargs
         ).result
+    if not _configured_dispatch_blocked(kwargs):
+        configured_outcome = _dispatch_configured_global_plot_style(
+            explainer, x, y, threshold, kwargs
+        )
+        if configured_outcome is not None:
+            return configured_outcome.result
 
     _reject_unconsumed_plot_kwargs("plot_global", kwargs, allowed=_PLOT_GLOBAL_KWARGS)
 

--- a/src/calibrated_explanations/plugins/manager.py
+++ b/src/calibrated_explanations/plugins/manager.py
@@ -1376,6 +1376,94 @@ class PluginManager:
             + ("; errors: " + "; ".join(errors) if errors else "")
         )
 
+    def resolve_plot_plugin_strict(
+        self,
+        identifier: str,
+        *,
+        renderer_override: str | None = None,
+    ) -> tuple[Any, str, bool]:
+        """Resolve exactly *identifier* to a registered plot plugin, or raise.
+
+        Unlike :meth:`resolve_plot_plugin`, no fallback identifiers are ever
+        appended: an explicitly requested style either resolves to the exact
+        registered plugin or fails with an actionable
+        :class:`~calibrated_explanations.utils.exceptions.ConfigurationError`.
+        Returns ``(plugin, identifier, trusted)`` where ``trusted`` reflects
+        whether both the builder and renderer passed the ADR-006 trust policy.
+        """
+        from .registry import (  # pylint: disable=import-outside-toplevel
+            find_plot_builder_descriptor,
+            find_plot_renderer_descriptor,
+            find_plot_style_descriptor,
+            list_plot_style_descriptors,
+        )
+
+        ensure_builtin_plugins()
+
+        if is_identifier_denied(identifier):
+            raise ConfigurationError(
+                f"Plot style '{identifier}' is denied via CE_DENY_PLUGIN. "
+                "Remove the identifier from the denylist to use it."
+            )
+
+        style_descriptor = find_plot_style_descriptor(identifier)
+        if style_descriptor is None:
+            registered = sorted(
+                descriptor.identifier for descriptor in list_plot_style_descriptors()
+            )
+            raise ConfigurationError(
+                f"Plot style '{identifier}' is not registered. Register the style "
+                "via calibrated_explanations.plugins.registry.register_plot_style "
+                f"(and its builder/renderer) before requesting it. Registered styles: {registered}."
+            )
+
+        builder_id = style_descriptor.metadata.get("builder_id")
+        renderer_id = style_descriptor.metadata.get("renderer_id")
+        builder_descriptor = find_plot_builder_descriptor(builder_id) if builder_id else None
+        renderer_descriptor = find_plot_renderer_descriptor(renderer_id) if renderer_id else None
+        if builder_descriptor is None or renderer_descriptor is None:
+            missing = []
+            if builder_descriptor is None:
+                missing.append(f"builder '{builder_id}'")
+            if renderer_descriptor is None:
+                missing.append(f"renderer '{renderer_id}'")
+            raise ConfigurationError(
+                f"Plot style '{identifier}' is registered but incomplete: "
+                f"missing {' and '.join(missing)}. Register the missing component(s) "
+                "before requesting the style."
+            )
+
+        trusted = find_plot_plugin_trusted(identifier) is not None
+        plugin = find_plot_plugin_trusted(identifier) or find_plot_plugin(identifier)
+        if plugin is None or not hasattr(plugin, "build") or not hasattr(plugin, "render"):
+            raise ConfigurationError(
+                f"Plot style '{identifier}' resolved to a plugin without build/render "
+                "implementations; check the registered builder and renderer objects."
+            )
+        if not trusted:
+            self._logger.info(
+                "Dispatching untrusted plot style '%s' without runtime context; "
+                "mark the builder and renderer trusted (ADR-006) to grant runtime access.",
+                identifier,
+            )
+
+        if not renderer_override:
+            renderer_override = self._config_manager.env("CE_PLOT_RENDERER")
+        if not renderer_override:
+            py_settings = self._pyproject_plots or {}
+            renderer_override = py_settings.get("renderer")
+        if renderer_override:
+            override_renderer = find_plot_renderer(renderer_override)
+            if override_renderer is None:
+                raise ConfigurationError(
+                    f"Requested plot renderer '{renderer_override}' is not registered; "
+                    f"cannot render explicitly requested style '{identifier}'."
+                )
+            with contextlib.suppress(Exception):
+                plugin.renderer = override_renderer
+
+        return plugin, identifier, trusted
+
     # =========================================================================
     # Orchestrator initialization (moved from CalibratedExplainer)
     # =========================================================================

--- a/src/calibrated_explanations/plugins/manager.py
+++ b/src/calibrated_explanations/plugins/manager.py
@@ -1440,27 +1440,33 @@ class PluginManager:
                 f"Plot style '{identifier}' resolved to a plugin without build/render "
                 "implementations; check the registered builder and renderer objects."
             )
-        if not trusted:
-            self._logger.info(
-                "Dispatching untrusted plot style '%s' without runtime context; "
-                "mark the builder and renderer trusted (ADR-006) to grant runtime access.",
-                identifier,
-            )
-
         if not renderer_override:
             renderer_override = self._config_manager.env("CE_PLOT_RENDERER")
         if not renderer_override:
             py_settings = self._pyproject_plots or {}
             renderer_override = py_settings.get("renderer")
         if renderer_override:
-            override_renderer = find_plot_renderer(renderer_override)
-            if override_renderer is None:
+            override_descriptor = find_plot_renderer_descriptor(renderer_override)
+            if override_descriptor is None:
                 raise ConfigurationError(
                     f"Requested plot renderer '{renderer_override}' is not registered; "
                     f"cannot render explicitly requested style '{identifier}'."
                 )
             with contextlib.suppress(Exception):
-                plugin.renderer = override_renderer
+                plugin.renderer = override_descriptor.renderer
+            # ADR-006: overriding the renderer changes the effective trust
+            # boundary. Runtime context must reflect the renderer actually in
+            # use, not the style's originally registered (and possibly more
+            # trusted) renderer -- otherwise an untrusted override renderer
+            # would inherit the original renderer's runtime access.
+            trusted = trusted and bool(override_descriptor.trusted)
+
+        if not trusted:
+            self._logger.info(
+                "Dispatching untrusted plot style '%s' without runtime context; "
+                "mark the builder and renderer trusted (ADR-006) to grant runtime access.",
+                identifier,
+            )
 
         return plugin, identifier, trusted
 

--- a/src/calibrated_explanations/plugins/plots.py
+++ b/src/calibrated_explanations/plugins/plots.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import (
     Any,
     Mapping,
@@ -36,7 +37,16 @@ PlotArtifact: TypeAlias = Union[PlotSpec, Mapping[str, Any], Any]
 
 @dataclass(frozen=True)
 class PlotRenderContext:
-    """Immutable context shared with plot plugins."""
+    """Immutable context shared with plot plugins.
+
+    ``runtime`` carries process-local runtime state (originating explainer and
+    the original plot request data) for trusted plugins. The top-level mapping
+    is read-only; contained objects are live references, not copies. Runtime
+    state is intentionally excluded from pickling: a round-tripped context
+    restores ``runtime`` as an empty read-only mapping (ADR-006: only trusted
+    plugins receive runtime access, and live explainer references are not
+    serialization-safe).
+    """
 
     explanation: Any
     instance_metadata: Mapping[str, Any]
@@ -47,21 +57,34 @@ class PlotRenderContext:
     save_ext: str | Sequence[str] | None
     options: Mapping[str, Any]
     plugin_config: Mapping[str, Any] = field(default_factory=dict)
+    runtime: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Freeze provisional plugin config before handing context to plugins."""
         object.__setattr__(self, "plugin_config", freeze_plugin_config(self.plugin_config))
+        object.__setattr__(self, "runtime", MappingProxyType(dict(self.runtime)))
 
     def __getstate__(self) -> dict:
-        """Return pickle-safe state with all MappingProxyType values thawed to plain dicts."""
-        return {k: thaw_plugin_config(v) for k, v in self.__dict__.items()}
+        """Return pickle-safe state with all MappingProxyType values thawed to plain dicts.
+
+        ``runtime`` holds live, process-local references (explainer, request
+        arrays) and is deliberately dropped: the pickled state stores an empty
+        mapping so unpickling never resurrects stale runtime objects.
+        """
+        state = {k: thaw_plugin_config(v) for k, v in self.__dict__.items() if k != "runtime"}
+        state["runtime"] = {}
+        return state
 
     def __setstate__(self, state: dict) -> None:
         """Restore state, re-freezing plugin_config via freeze_plugin_config."""
         for key, value in state.items():
             if key == "plugin_config":
                 value = freeze_plugin_config(value)
+            if key == "runtime":
+                value = MappingProxyType(dict(value or {}))
             object.__setattr__(self, key, value)
+        if "runtime" not in state:
+            object.__setattr__(self, "runtime", MappingProxyType({}))
 
 
 @dataclass

--- a/tests/plugins/test_protocols.py
+++ b/tests/plugins/test_protocols.py
@@ -227,6 +227,82 @@ def test_plot_context_is_frozen() -> None:
     assert ctx.style == original_style
 
 
+def test_should_default_runtime_to_empty_read_only_mapping_when_omitted() -> None:
+    ctx = PlotRenderContext(
+        explanation=None,
+        instance_metadata={"index": 0},
+        style="legacy",
+        intent={"kind": "bar"},
+        show=False,
+        path=None,
+        save_ext=None,
+        options={},
+    )
+
+    assert dict(ctx.runtime) == {}
+    with pytest.raises(TypeError):
+        ctx.runtime["explainer"] = object()  # type: ignore[index]
+
+
+def test_should_accept_positional_construction_without_runtime_field() -> None:
+    # Pre-runtime positional call shape must keep working unchanged.
+    ctx = PlotRenderContext(
+        None, {"index": 0}, "legacy", {"kind": "bar"}, False, None, None, {"dpi": 72}, {}
+    )
+
+    assert ctx.options == {"dpi": 72}
+    assert dict(ctx.runtime) == {}
+
+
+def test_should_share_runtime_references_without_mutating_caller_mapping() -> None:
+    explainer = object()
+    caller_runtime = {"scope": "instance", "explainer": explainer}
+    ctx = PlotRenderContext(
+        explanation=None,
+        instance_metadata={"index": 0},
+        style="vendor.style",
+        intent={"kind": "bar"},
+        show=False,
+        path=None,
+        save_ext=None,
+        options={},
+        runtime=caller_runtime,
+    )
+
+    # Live reference, not a deep copy; caller mapping stays untouched and
+    # detached from the frozen context copy.
+    assert ctx.runtime["explainer"] is explainer
+    caller_runtime["extra"] = "later"
+    assert "extra" not in ctx.runtime
+    assert caller_runtime == {"scope": "instance", "explainer": explainer, "extra": "later"}
+    with pytest.raises(TypeError):
+        ctx.runtime["scope"] = "global"  # type: ignore[index]
+
+
+def test_should_drop_runtime_state_when_context_is_pickled() -> None:
+    import pickle
+
+    ctx = PlotRenderContext(
+        explanation=None,
+        instance_metadata={"index": 0},
+        style="vendor.style",
+        intent={"kind": "bar"},
+        show=False,
+        path=None,
+        save_ext=None,
+        options={"filter_top": 3},
+        runtime={"scope": "instance", "explainer": object()},
+    )
+
+    restored = pickle.loads(pickle.dumps(ctx))
+
+    # Documented contract: runtime is process-local and never serialized;
+    # everything else round-trips.
+    assert dict(restored.runtime) == {}
+    assert restored.options == {"filter_top": 3}
+    assert restored.style == "vendor.style"
+
+
 class GoodPlotBuilder:
     plugin_meta = {
         "name": "plot",

--- a/tests/unit/test_plot_default_promotion.py
+++ b/tests/unit/test_plot_default_promotion.py
@@ -70,7 +70,10 @@ def install_public_global_plot_plugin(
         plugin_meta = {"style": style}
 
         def build(self, context: object) -> object:
-            return {"plot_spec": context.style, "context": context}
+            # Renderer-native artifact shape: strict third-party dispatch runs
+            # validate_plot_artifact, which must pass non-PlotSpec artifacts
+            # through untouched.
+            return {"resolved_style": context.style, "context": context}
 
         def render(self, artifact: object, *, context: object) -> PlotRenderResult:
             return PlotRenderResult(artifact=artifact, figure=None, saved_paths=(), extras={})
@@ -88,6 +91,15 @@ def install_public_global_plot_plugin(
                 explicit_style or "plot_spec.default",
                 (explicit_style or "plot_spec.default", "legacy"),
             )
+        ),
+    )
+    # Explicit third-party styles resolve through the strict, no-fallback path.
+    monkeypatch.setattr(
+        explainer.plugin_manager,
+        "resolve_plot_plugin_strict",
+        lambda identifier, *, renderer_override=None: (
+            resolve_calls.append((identifier, renderer_override))
+            or (PlotPlugin(), identifier, True)
         ),
     )
     return resolve_calls
@@ -704,7 +716,7 @@ def test_should_return_plugin_result_from_calibrated_explainer_plot_when_explici
 
     assert isinstance(result, PlotRenderResult)
     assert result.artifact is not None
-    assert result.artifact["plot_spec"] == "plotly.global.instance_explorer"
+    assert result.artifact["resolved_style"] == "plotly.global.instance_explorer"
     assert resolve_calls == [("plotly.global.instance_explorer", None)]
 
 
@@ -723,7 +735,7 @@ def test_should_return_plugin_result_from_wrap_plot_with_targets_when_explicit_g
 
     assert isinstance(result, PlotRenderResult)
     assert result.artifact is not None
-    assert result.artifact["plot_spec"] == "plotly.global.instance_explorer"
+    assert result.artifact["resolved_style"] == "plotly.global.instance_explorer"
     assert resolve_calls == [("plotly.global.instance_explorer", None)]
 
 
@@ -737,7 +749,7 @@ def test_should_preserve_default_global_plot_behavior_from_wrap_plot_when_style_
 
     assert isinstance(result, PlotRenderResult)
     assert result.artifact is not None
-    assert result.artifact["plot_spec"] == "plot_spec.default"
+    assert result.artifact["resolved_style"] == "plot_spec.default"
     assert resolve_calls == [("plot_spec.default", None)]
 
 

--- a/tests/unit/test_plot_third_party_dispatch.py
+++ b/tests/unit/test_plot_third_party_dispatch.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import numpy as np
 import pytest
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LinearRegression, LogisticRegression
 
 import calibrated_explanations.explanations.explanation as explanation_module
 from calibrated_explanations import plotting
@@ -141,6 +141,17 @@ def calibrated_wrapper() -> WrapCalibratedExplainer:
     wrapper = WrapCalibratedExplainer(LogisticRegression(random_state=0, solver="liblinear"))
     wrapper.fit(x[:20], y[:20])
     wrapper.calibrate(x[20:32], y[20:32])
+    return wrapper
+
+
+@pytest.fixture()
+def calibrated_regression_wrapper() -> WrapCalibratedExplainer:
+    rng = np.random.default_rng(11)
+    x = rng.normal(size=(60, 3))
+    y = 2.0 * x[:, 0] - 0.5 * x[:, 1] + rng.normal(scale=0.4, size=60)
+    wrapper = WrapCalibratedExplainer(LinearRegression())
+    wrapper.fit(x[:30], y[:30])
+    wrapper.calibrate(x[30:50], y[30:50])
     return wrapper
 
 
@@ -351,6 +362,45 @@ def test_should_forward_payload_options_and_runtime_when_global_style_selected(
     assert context.runtime["threshold"] is None
     assert context.runtime["bins"] is None
     assert len(renderer.calls) == 1
+
+
+def test_should_build_global_bounds_from_requested_regression_percentiles(
+    calibrated_regression_wrapper,
+    register_synthetic_style,
+    monkeypatch,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.global.regression")
+    explainer = calibrated_regression_wrapper.explainer
+    x_test = np.array([[0.1, -0.2, 0.3], [0.5, 0.1, -0.4]])
+    percentiles = (20, 80)
+    expected_predict, (expected_low, expected_high) = explainer.predict(
+        x_test, uq_interval=True, low_high_percentiles=percentiles
+    )
+    prediction_calls: list[dict[str, Any]] = []
+    original_predict = explainer.predict
+
+    def _record_predict(x: Any, **kwargs: Any) -> Any:
+        prediction_calls.append(dict(kwargs))
+        return original_predict(x, **kwargs)
+
+    monkeypatch.setattr(explainer, "predict", _record_predict)
+
+    explainer.plot(
+        x_test,
+        style="synthetic.global.regression",
+        low_high_percentiles=percentiles,
+        show=False,
+    )
+
+    payload = builder.contexts[0].options["payload"]
+    assert prediction_calls == [
+        {"uq_interval": True, "bins": None, "low_high_percentiles": percentiles}
+    ]
+    np.testing.assert_allclose(payload["predict"], expected_predict)
+    np.testing.assert_allclose(payload["low"], expected_low)
+    np.testing.assert_allclose(payload["high"], expected_high)
+    assert np.all(np.asarray(payload["low"]) <= np.asarray(payload["predict"]))
+    assert np.all(np.asarray(payload["predict"]) <= np.asarray(payload["high"]))
 
 
 def test_should_reject_caller_supplied_payload_when_global_style_selected(
@@ -576,6 +626,34 @@ def test_should_accept_matching_path_and_filename_for_plugin_dispatch(
     assert builder.contexts[0].path == "a/one.html"
 
 
+@pytest.mark.parametrize(
+    ("transport", "expected_path", "expected_show"),
+    [
+        ({"filename": ""}, None, True),
+        ({"path": ""}, None, True),
+        ({"path": "out.html", "filename": ""}, "out.html", False),
+        ({"path": "", "filename": "out.html"}, "out.html", False),
+        ({"filename": "", "show": False}, None, False),
+    ],
+)
+def test_should_treat_exact_empty_transport_paths_as_absent_when_plugin_dispatched(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+    transport,
+    expected_path,
+    expected_show,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    factual.plot(style="synthetic.factual", **transport)
+
+    context = builder.contexts[0]
+    assert context.path == expected_path
+    assert context.show is expected_show
+
+
 def test_should_default_show_true_when_no_output_path_for_plugin_dispatch(
     calibrated_wrapper,
     register_synthetic_style,
@@ -694,6 +772,90 @@ def test_should_treat_none_renderer_result_as_handled_when_configured_style_disp
     result = factual.plot(show=False)
 
     assert result is None
+
+
+def test_should_dispatch_configured_factual_style_when_use_legacy_false(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.configured.factual.nonlegacy")
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = (
+        "synthetic.configured.factual.nonlegacy"
+    )
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = factual.plot(use_legacy=False, filter_top=5, uncertainty=True, show=False)
+
+    assert result == "renderer-result"
+    assert builder.contexts[0].options["filter_top"] == 5
+    assert builder.contexts[0].options["uncertainty"] is True
+
+
+def test_should_dispatch_configured_alternative_style_when_use_legacy_false(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.configured.alternative.nonlegacy")
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = (
+        "synthetic.configured.alternative.nonlegacy"
+    )
+    alternative = calibrated_wrapper.explore_alternatives(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = alternative.plot(use_legacy=False, filter_top=6, show=False)
+
+    assert result == "renderer-result"
+    assert builder.contexts[0].options["filter_top"] == 6
+
+
+def test_should_treat_none_result_as_handled_for_configured_global_style_when_use_legacy_false(
+    calibrated_wrapper,
+    register_synthetic_style,
+) -> None:
+    builder, renderer = register_synthetic_style(
+        "synthetic.configured.global.nonlegacy", renderer_result=None
+    )
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = (
+        "synthetic.configured.global.nonlegacy"
+    )
+
+    result = calibrated_wrapper.explainer.plot(
+        np.array([[0.1, -0.2, 0.3], [0.4, 0.1, -0.2]]),
+        use_legacy=False,
+        show=False,
+    )
+
+    assert result is None
+    assert len(builder.contexts) == 1
+    assert len(renderer.calls) == 1
+
+
+def test_should_bypass_configured_legacy_global_style_when_use_legacy_false(
+    calibrated_wrapper,
+    monkeypatch,
+) -> None:
+    explainer = calibrated_wrapper.explainer
+    explainer.plugin_manager.plot_style_override = "legacy"
+    resolved_styles: list[str | None] = []
+    original_resolve = explainer.plugin_manager.resolve_plot_plugin
+
+    def _record_resolve(*, explicit_style=None, renderer_override=None):
+        resolved_styles.append(explicit_style)
+        return original_resolve(
+            explicit_style=explicit_style,
+            renderer_override=renderer_override,
+        )
+
+    monkeypatch.setattr(explainer.plugin_manager, "resolve_plot_plugin", _record_resolve)
+
+    explainer.plot(
+        np.array([[0.1, -0.2, 0.3], [0.4, 0.1, -0.2]]),
+        use_legacy=False,
+        show=False,
+    )
+
+    assert resolved_styles == ["plot_spec.default"]
 
 
 def test_should_not_dispatch_configured_style_when_use_legacy_true(

--- a/tests/unit/test_plot_third_party_dispatch.py
+++ b/tests/unit/test_plot_third_party_dispatch.py
@@ -1,0 +1,607 @@
+"""Third-party plot-style dispatch contract (v1.0.0rc2).
+
+Why a new test file?
+--------------------
+These tests cover the strict third-party dispatch contract introduced for
+v1.0.0rc2: explicitly selected registered styles receive the complete,
+unconsumed plugin request through ``FactualExplanation.plot``,
+``AlternativeExplanation.plot``, and ``plot_global`` without monkey-patching
+any CE callable. The behavior is a single coherent public contract spanning
+three surfaces and does not belong to the PlotSpec default-promotion suite
+(``test_plot_default_promotion.py``), which governs CE-owned style routing.
+
+All plugins are registered through the public registry and ADR-006 trust
+mechanisms; no CE plotting callable is replaced or wrapped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from sklearn.linear_model import LogisticRegression
+
+import calibrated_explanations.explanations.explanation as explanation_module
+from calibrated_explanations import plotting
+from calibrated_explanations.core.wrap_explainer import WrapCalibratedExplainer
+from calibrated_explanations.plugins.registry import (
+    mark_plot_builder_trusted,
+    mark_plot_renderer_trusted,
+    register_plot_builder,
+    register_plot_renderer,
+    register_plot_style,
+    reset_plugin_catalog,
+)
+from calibrated_explanations.utils.exceptions import ConfigurationError, ValidationError
+
+
+def _plugin_meta(name: str, capability: str, *, trusted: bool) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "name": name,
+        "version": "0.0.1",
+        "provider": "ce-tests",
+        "data_modalities": ("tabular",),
+        "dependencies": (),
+        "capabilities": [capability],
+        "style": name,
+        "output_formats": ["object"],
+        "legacy_compatible": False,
+        "supports_interactive": False,
+        "trusted": trusted,
+        "trust": trusted,
+    }
+
+
+class RecordingBuilder:
+    def __init__(self, name: str, *, trusted: bool, error: Exception | None = None):
+        self.plugin_meta = _plugin_meta(name, "plot:builder", trusted=trusted)
+        self.contexts: list[Any] = []
+        self.error = error
+
+    def build(self, context: Any) -> Any:
+        self.contexts.append(context)
+        if self.error is not None:
+            raise self.error
+        return {"synthetic_artifact": context.style}
+
+
+class RecordingRenderer:
+    def __init__(
+        self,
+        name: str,
+        *,
+        trusted: bool,
+        result: Any = "renderer-result",
+        error: Exception | None = None,
+    ):
+        self.plugin_meta = _plugin_meta(name, "plot:renderer", trusted=trusted)
+        self.calls: list[tuple[Any, Any]] = []
+        self.result = result
+        self.error = error
+
+    def render(self, artifact: Any, *, context: Any) -> Any:
+        self.calls.append((artifact, context))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+@pytest.fixture()
+def register_synthetic_style():
+    """Register a synthetic style via the public registry; reset afterwards."""
+    registered: list[str] = []
+
+    def _register(
+        style: str,
+        *,
+        trusted: bool = True,
+        renderer_result: Any = "renderer-result",
+        build_error: Exception | None = None,
+        render_error: Exception | None = None,
+        builder: Any = None,
+    ) -> tuple[Any, RecordingRenderer]:
+        builder = builder or RecordingBuilder(
+            f"{style}.builder", trusted=trusted, error=build_error
+        )
+        renderer = RecordingRenderer(
+            f"{style}.renderer", trusted=trusted, result=renderer_result, error=render_error
+        )
+        register_plot_builder(f"{style}.builder", builder, source="manual")
+        register_plot_renderer(f"{style}.renderer", renderer, source="manual")
+        if trusted:
+            # ADR-006 keyed trust helpers: the public operator trust mechanism.
+            mark_plot_builder_trusted(f"{style}.builder")
+            mark_plot_renderer_trusted(f"{style}.renderer")
+        register_plot_style(
+            style,
+            metadata={
+                "style": style,
+                "builder_id": f"{style}.builder",
+                "renderer_id": f"{style}.renderer",
+                "fallbacks": (),
+                "legacy_compatible": False,
+                "is_default": False,
+                "default_for": (),
+            },
+        )
+        registered.append(style)
+        return builder, renderer
+
+    yield _register
+    reset_plugin_catalog(kind="plot")
+
+
+@pytest.fixture()
+def calibrated_wrapper() -> WrapCalibratedExplainer:
+    rng = np.random.default_rng(7)
+    x = rng.normal(size=(40, 3))
+    y = (x[:, 0] + x[:, 1] > 0).astype(int)
+    wrapper = WrapCalibratedExplainer(LogisticRegression(random_state=0, solver="liblinear"))
+    wrapper.fit(x[:20], y[:20])
+    wrapper.calibrate(x[20:32], y[20:32])
+    return wrapper
+
+
+@pytest.fixture()
+def guard_builtin_instance_plotting(monkeypatch: pytest.MonkeyPatch):
+    """Fail loudly if third-party dispatch leaks into built-in plotting."""
+
+    def _fail(name: str):
+        def _raiser(*args: Any, **kwargs: Any) -> None:
+            raise AssertionError(f"built-in {name} must not run for third-party styles")
+
+        return _raiser
+
+    monkeypatch.setattr(explanation_module, "plot_probabilistic", _fail("plot_probabilistic"))
+    monkeypatch.setattr(explanation_module, "plot_regression", _fail("plot_regression"))
+    monkeypatch.setattr(explanation_module, "plot_alternative", _fail("plot_alternative"))
+    monkeypatch.setattr(explanation_module, "plot_triangular", _fail("plot_triangular"))
+    monkeypatch.setattr(explanation_module, "calculate_metrics", _fail("calculate_metrics"))
+    monkeypatch.setattr(plotting, "_require_matplotlib", _fail("_require_matplotlib"))
+
+
+def _public_runtime_explainer(explanation: Any) -> Any:
+    """Unwrap the explanation's frozen explainer snapshot via public accessors."""
+    resolved = explanation.get_explainer()
+    while not hasattr(resolved, "plugin_manager"):
+        resolved = resolved.explainer
+    return resolved
+
+
+def _spy_rank_features(monkeypatch: pytest.MonkeyPatch, explanation: Any) -> list[int]:
+    calls: list[int] = []
+    original = explanation.rank_features
+
+    def _spy(*args: Any, **kwargs: Any) -> Any:
+        calls.append(1)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(type(explanation), "rank_features", staticmethod(_spy))
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Factual surface
+# ---------------------------------------------------------------------------
+
+
+def test_should_forward_complete_factual_request_when_third_party_style_selected(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+    monkeypatch,
+) -> None:
+    builder, renderer = register_synthetic_style("synthetic.factual")
+    x_test = np.array([[0.1, -0.2, 0.3]])
+    factual = calibrated_wrapper.explain_factual(x_test)[0]
+    rank_calls = _spy_rank_features(monkeypatch, factual)
+
+    result = factual.plot(
+        filter_top=5,
+        style="synthetic.factual",
+        uncertainty=True,
+        rnk_metric="ensured",
+        rnk_weight=0.25,
+        vendor_options={"nested": {"depth": 2}},
+        show=False,
+        path="out/custom.synthetic.bin",
+        save_ext=["synthetic"],
+    )
+
+    assert result == "renderer-result"
+    assert len(builder.contexts) == 1
+    context = builder.contexts[0]
+    assert context.explanation is factual
+    assert context.intent["type"] == "factual"
+    assert context.style == "synthetic.factual"
+    assert context.options["filter_top"] == 5
+    assert context.options["uncertainty"] is True
+    assert context.options["rnk_metric"] == "ensured"
+    assert context.options["rnk_weight"] == 0.25
+    assert context.options["vendor_options"] == {"nested": {"depth": 2}}
+    assert context.show is False
+    assert context.path == "out/custom.synthetic.bin"
+    assert context.save_ext == ("synthetic",)
+    assert context.runtime["scope"] == "instance"
+    # Instance explanations carry a frozen snapshot of the originating
+    # explainer; the runtime reference resolves to that public snapshot.
+    assert context.runtime["explainer"] is _public_runtime_explainer(factual)
+    assert context.runtime["instance_index"] == factual.index
+    assert renderer.calls[0][0] == {"synthetic_artifact": "synthetic.factual"}
+    assert not rank_calls
+
+
+def test_should_include_default_filter_top_none_when_factual_plugin_dispatched(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    factual.plot(style="synthetic.factual", show=False)
+
+    assert builder.contexts[0].options["filter_top"] is None
+
+
+def test_should_treat_none_renderer_result_as_handled_when_factual_plugin_returns_none(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, renderer = register_synthetic_style("synthetic.factual", renderer_result=None)
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = factual.plot(style="synthetic.factual", show=False)
+
+    assert result is None
+    assert len(builder.contexts) == 1
+    assert len(renderer.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Alternative surface
+# ---------------------------------------------------------------------------
+
+
+def test_should_forward_complete_alternative_request_when_third_party_style_selected(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+    monkeypatch,
+) -> None:
+    builder, renderer = register_synthetic_style("synthetic.alternative", renderer_result=None)
+    alternative = calibrated_wrapper.explore_alternatives(np.array([[0.1, -0.2, 0.3]]))[0]
+    rank_calls = _spy_rank_features(monkeypatch, alternative)
+
+    result = alternative.plot(
+        filter_top=8,
+        style="synthetic.alternative",
+        rnk_metric="ensured",
+        rnk_weight=0.5,
+        vendor_flag="on",
+        show=False,
+    )
+
+    assert result is None
+    context = builder.contexts[0]
+    assert context.explanation is alternative
+    assert context.intent["type"] == "alternative"
+    assert context.style == "synthetic.alternative"
+    assert context.options["filter_top"] == 8
+    assert context.options["rnk_metric"] == "ensured"
+    assert context.options["rnk_weight"] == 0.5
+    assert context.options["vendor_flag"] == "on"
+    assert context.runtime["scope"] == "instance"
+    assert context.runtime["explainer"] is _public_runtime_explainer(alternative)
+    assert len(renderer.calls) == 1
+    assert not rank_calls
+
+
+def test_should_not_rewrite_third_party_style_when_alternative_plugin_dispatched(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("vendor.ensured.variant")
+    alternative = calibrated_wrapper.explore_alternatives(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    alternative.plot(style="vendor.ensured.variant", show=False)
+
+    assert builder.contexts[0].style == "vendor.ensured.variant"
+
+
+# ---------------------------------------------------------------------------
+# Global and dashboard surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_should_forward_payload_options_and_runtime_when_global_style_selected(
+    calibrated_wrapper,
+    register_synthetic_style,
+) -> None:
+    builder, renderer = register_synthetic_style("synthetic.global")
+    explainer = calibrated_wrapper.explainer
+    x_test = np.array([[0.1, -0.2, 0.3], [0.5, 0.1, -0.4]])
+    y_test = np.array([1, 0])
+
+    result = explainer.plot(
+        x_test,
+        y_test,
+        style="synthetic.global",
+        aggregate_positions=True,
+        global_options={"cards": ("a", "b")},
+        show=False,
+    )
+
+    assert result == "renderer-result"
+    context = builder.contexts[0]
+    assert context.intent["type"] == "global"
+    assert context.options["aggregate_positions"] is True
+    assert context.options["global_options"] == {"cards": ("a", "b")}
+    payload = context.options["payload"]
+    assert payload["proba"] is not None
+    assert payload["x"] is x_test
+    assert context.runtime["scope"] == "global"
+    assert context.runtime["explainer"] is explainer
+    assert context.runtime["x"] is x_test
+    assert context.runtime["y"] is y_test
+    assert context.runtime["threshold"] is None
+    assert context.runtime["bins"] is None
+    assert len(renderer.calls) == 1
+
+
+def test_should_reject_caller_supplied_payload_when_global_style_selected(
+    calibrated_wrapper,
+    register_synthetic_style,
+) -> None:
+    register_synthetic_style("synthetic.global")
+
+    with pytest.raises(ValidationError, match="reserved"):
+        calibrated_wrapper.explainer.plot(
+            np.array([[0.1, -0.2, 0.3]]),
+            style="synthetic.global",
+            payload={"user": "value"},
+            show=False,
+        )
+
+
+def test_should_let_trusted_dashboard_plugin_drive_public_explainer_when_dispatched(
+    calibrated_wrapper,
+    register_synthetic_style,
+) -> None:
+    class DashboardBuilder:
+        plugin_meta = _plugin_meta("synthetic.dashboard.builder", "plot:builder", trusted=True)
+
+        def __init__(self) -> None:
+            self.contexts: list[Any] = []
+
+        def build(self, context: Any) -> Any:
+            self.contexts.append(context)
+            runtime = context.runtime
+            explainer = runtime["explainer"]
+            row = np.asarray(runtime["x"])[:1]
+            factual = explainer.explain_factual(row)[0]
+            alternatives = explainer.explore_alternatives(row)[0]
+            return {
+                "synthetic_dashboard": True,
+                "factual_index": factual.index,
+                "alternative_index": alternatives.index,
+                "factual_options": dict(context.options.get("factual_options", {})),
+            }
+
+    builder = DashboardBuilder()
+    _, renderer = register_synthetic_style("synthetic.dashboard", builder=builder)
+
+    result = calibrated_wrapper.explainer.plot(
+        np.array([[0.1, -0.2, 0.3], [0.5, 0.1, -0.4]]),
+        style="synthetic.dashboard",
+        factual_options={"filter_top": 4},
+        alternative_options={"filter_top": 6},
+        show=False,
+    )
+
+    assert result == "renderer-result"
+    artifact = renderer.calls[0][0]
+    assert artifact["synthetic_dashboard"] is True
+    assert artifact["factual_index"] == 0
+    assert artifact["alternative_index"] == 0
+    assert artifact["factual_options"] == {"filter_top": 4}
+
+
+# ---------------------------------------------------------------------------
+# Strict resolution
+# ---------------------------------------------------------------------------
+
+
+def test_should_raise_actionable_error_when_explicit_style_is_unregistered(
+    calibrated_wrapper,
+    guard_builtin_instance_plotting,
+) -> None:
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    with pytest.raises(ConfigurationError) as excinfo:
+        factual.plot(style="vendor.missing", show=False)
+
+    message = str(excinfo.value)
+    assert "vendor.missing" in message
+    assert "not registered" in message
+    assert "global explanations" not in message
+
+
+def test_should_raise_when_explicit_style_is_denied(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+    monkeypatch,
+) -> None:
+    register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+    monkeypatch.setenv("CE_DENY_PLUGIN", "synthetic.factual")
+    from calibrated_explanations.core.config_manager import (
+        reset_process_config_manager_for_testing,
+    )
+
+    reset_process_config_manager_for_testing()
+    try:
+        with pytest.raises(ConfigurationError, match="denied"):
+            factual.plot(style="synthetic.factual", show=False)
+    finally:
+        monkeypatch.delenv("CE_DENY_PLUGIN", raising=False)
+        reset_process_config_manager_for_testing()
+
+
+def test_should_raise_when_renderer_override_unregistered_for_explicit_style(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    with pytest.raises(ConfigurationError, match="renderer"):
+        factual.plot(style="synthetic.factual", renderer="vendor.absent.renderer", show=False)
+
+
+def test_should_withhold_runtime_context_when_explicit_style_is_untrusted(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.untrusted", trusted=False)
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = factual.plot(style="synthetic.untrusted", show=False)
+
+    assert result == "renderer-result"
+    context = builder.contexts[0]
+    assert dict(context.runtime) == {}
+
+
+def test_should_surface_builder_error_without_fallback_when_explicit_style_fails(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    register_synthetic_style("synthetic.broken.build", build_error=RuntimeError("builder boom"))
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    with pytest.raises(RuntimeError, match="builder boom"):
+        factual.plot(style="synthetic.broken.build", show=False)
+
+
+def test_should_surface_renderer_error_without_fallback_when_explicit_style_fails(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    register_synthetic_style("synthetic.broken.render", render_error=RuntimeError("render boom"))
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    with pytest.raises(RuntimeError, match="render boom"):
+        factual.plot(style="synthetic.broken.render", show=False)
+
+
+def test_should_raise_when_explicit_style_conflicts_with_use_legacy(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    with pytest.raises(ValidationError, match="use_legacy"):
+        factual.plot(style="synthetic.factual", use_legacy=True, show=False)
+
+
+def test_should_raise_when_explicit_style_conflicts_with_string_style_override(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    with pytest.raises(ValidationError, match="style_override"):
+        factual.plot(style="synthetic.factual", style_override="legacy", show=False)
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+def test_should_use_filename_as_context_path_without_rewriting_when_plugin_dispatched(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    factual.plot(style="synthetic.factual", filename="reports/plot.custom.ext")
+
+    context = builder.contexts[0]
+    assert context.path == "reports/plot.custom.ext"
+    assert context.show is False
+    assert "filename" not in context.options
+
+
+def test_should_raise_when_path_and_filename_conflict_for_plugin_dispatch(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    with pytest.raises(ValidationError, match="path"):
+        factual.plot(
+            style="synthetic.factual", path="a/one.html", filename="b/two.html", show=False
+        )
+
+
+def test_should_accept_matching_path_and_filename_for_plugin_dispatch(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    factual.plot(style="synthetic.factual", path="a/one.html", filename="a/one.html", show=False)
+
+    assert builder.contexts[0].path == "a/one.html"
+
+
+def test_should_default_show_true_when_no_output_path_for_plugin_dispatch(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    factual.plot(style="synthetic.factual")
+
+    context = builder.contexts[0]
+    assert context.show is True
+    assert context.path is None
+    assert context.save_ext is None
+
+
+def test_should_preserve_explicit_show_true_when_output_path_supplied(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    factual.plot(style="synthetic.factual", path="out/plot.html", show=True)
+
+    context = builder.contexts[0]
+    assert context.show is True
+    assert context.path == "out/plot.html"

--- a/tests/unit/test_plot_third_party_dispatch.py
+++ b/tests/unit/test_plot_third_party_dispatch.py
@@ -605,3 +605,207 @@ def test_should_preserve_explicit_show_true_when_output_path_supplied(
     context = builder.contexts[0]
     assert context.show is True
     assert context.path == "out/plot.html"
+
+
+# ---------------------------------------------------------------------------
+# Configured (non-explicit) selection channels: manager override, style_override
+# ---------------------------------------------------------------------------
+#
+# A style selected without an explicit style="..." kwarg -- via
+# PluginManager.plot_style_override, CE_PLOT_STYLE, pyproject.toml, or the
+# plugin-dependency chain -- must dispatch through the same raw-request path
+# as an explicit style, not the built-in option-consuming path. The
+# explanation snapshot each explanation carries is frozen at explain_factual/
+# explore_alternatives time, so the configured preference must be set on the
+# live explainer BEFORE the explanation is generated.
+
+
+def test_should_forward_complete_factual_request_when_style_selected_via_manager_override(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.configured.factual")
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = "synthetic.configured.factual"
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = factual.plot(
+        filter_top=5, uncertainty=True, rnk_metric="ensured", rnk_weight=0.25, show=False
+    )
+
+    assert result == "renderer-result"
+    context = builder.contexts[0]
+    assert context.style == "synthetic.configured.factual"
+    assert context.options["filter_top"] == 5
+    assert context.options["uncertainty"] is True
+    assert context.options["rnk_metric"] == "ensured"
+    assert context.options["rnk_weight"] == 0.25
+    assert context.runtime["scope"] == "instance"
+
+
+def test_should_forward_complete_alternative_request_when_style_selected_via_manager_override(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.configured.alternative")
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = (
+        "synthetic.configured.alternative"
+    )
+    alternative = calibrated_wrapper.explore_alternatives(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = alternative.plot(filter_top=6, rnk_metric="ensured", show=False)
+
+    assert result == "renderer-result"
+    context = builder.contexts[0]
+    assert context.options["filter_top"] == 6
+    assert context.options["rnk_metric"] == "ensured"
+
+
+def test_should_forward_complete_global_request_when_style_selected_via_manager_override(
+    calibrated_wrapper,
+    register_synthetic_style,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.configured.global")
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = "synthetic.configured.global"
+
+    result = calibrated_wrapper.explainer.plot(
+        np.array([[0.1, -0.2, 0.3], [0.4, 0.1, -0.2]]),
+        aggregate_positions=True,
+        show=False,
+    )
+
+    assert result == "renderer-result"
+    context = builder.contexts[0]
+    assert context.options["aggregate_positions"] is True
+    assert "payload" in context.options
+    assert context.runtime["scope"] == "global"
+
+
+def test_should_treat_none_renderer_result_as_handled_when_configured_style_dispatched(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    register_synthetic_style("synthetic.configured.none", renderer_result=None)
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = "synthetic.configured.none"
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = factual.plot(show=False)
+
+    assert result is None
+
+
+def test_should_not_dispatch_configured_style_when_use_legacy_true(
+    calibrated_wrapper,
+    register_synthetic_style,
+    monkeypatch,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.configured.bypass")
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = "synthetic.configured.bypass"
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+    monkeypatch.setattr(explanation_module, "plot_probabilistic", lambda *a, **k: "legacy-handled")
+
+    result = factual.plot(use_legacy=True, show=False)
+
+    assert result == "legacy-handled"
+    assert not builder.contexts, "configured third-party style must not run when use_legacy=True"
+
+
+def test_should_fall_through_silently_when_configured_style_is_unregistered(
+    calibrated_wrapper,
+    monkeypatch,
+) -> None:
+    calibrated_wrapper.explainer.plugin_manager.plot_style_override = "vendor.never.registered"
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+    monkeypatch.setattr(
+        explanation_module, "plot_probabilistic", lambda *a, **k: "fallback-handled"
+    )
+
+    result = factual.plot(show=False)
+
+    assert result == "fallback-handled"
+
+
+def test_should_forward_complete_factual_request_when_style_selected_via_style_override_kwarg(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.viaoverride.factual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = factual.plot(
+        style_override="synthetic.viaoverride.factual",
+        uncertainty=True,
+        rnk_metric="ensured",
+        show=False,
+    )
+
+    assert result == "renderer-result"
+    context = builder.contexts[0]
+    assert context.style == "synthetic.viaoverride.factual"
+    assert context.options["uncertainty"] is True
+
+
+def test_should_forward_complete_alternative_request_when_style_selected_via_style_override_kwarg(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.viaoverride.alternative")
+    alternative = calibrated_wrapper.explore_alternatives(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    result = alternative.plot(
+        style_override="synthetic.viaoverride.alternative", filter_top=4, show=False
+    )
+
+    assert result == "renderer-result"
+    context = builder.contexts[0]
+    assert context.options["filter_top"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Renderer-override trust recomputation (ADR-006)
+# ---------------------------------------------------------------------------
+
+
+def test_should_withhold_runtime_when_renderer_override_is_untrusted(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.overridetrust", trusted=True)
+    untrusted_renderer = RecordingRenderer("synthetic.untrusted.renderer", trusted=False)
+    register_plot_renderer("synthetic.untrusted.renderer.id", untrusted_renderer, source="manual")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    factual.plot(
+        style="synthetic.overridetrust",
+        renderer="synthetic.untrusted.renderer.id",
+        show=False,
+    )
+
+    context = builder.contexts[0]
+    assert dict(context.runtime) == {}
+
+
+def test_should_keep_runtime_when_renderer_override_is_also_trusted(
+    calibrated_wrapper,
+    register_synthetic_style,
+    guard_builtin_instance_plotting,
+) -> None:
+    builder, _ = register_synthetic_style("synthetic.overridetrust2", trusted=True)
+    trusted_renderer = RecordingRenderer("synthetic.trusted.renderer", trusted=True)
+    register_plot_renderer("synthetic.trusted.renderer.id", trusted_renderer, source="manual")
+    mark_plot_renderer_trusted("synthetic.trusted.renderer.id")
+    factual = calibrated_wrapper.explain_factual(np.array([[0.1, -0.2, 0.3]]))[0]
+
+    factual.plot(
+        style="synthetic.overridetrust2",
+        renderer="synthetic.trusted.renderer.id",
+        show=False,
+    )
+
+    context = builder.contexts[0]
+    assert context.runtime["scope"] == "instance"

--- a/tests/unit/test_plotting_coverage.py
+++ b/tests/unit/test_plotting_coverage.py
@@ -346,7 +346,14 @@ def test_plot_global__should_warn_and_log_when_renderer_override_missing(
                     )
                 return dummy, explicit_style or "dummy-style", ("dummy-style", "legacy")
 
-            self.plugin_manager = SimpleNamespace(resolve_plot_plugin=_resolve_plot_plugin)
+            # Configured (non-explicit) style preference: explicit styles now
+            # resolve strictly and raise instead of warning, so the visible
+            # renderer-override fallback is exercised through the configured
+            # manager preference path.
+            self.plugin_manager = SimpleNamespace(
+                resolve_plot_plugin=_resolve_plot_plugin,
+                plot_style_override="dummy-style",
+            )
 
         def predict_proba(self, _x: Any, *, uq_interval: bool, threshold: Any, bins: Any):
             return [0.2, 0.8], ([0.1, 0.7], [0.3, 0.9])
@@ -362,7 +369,6 @@ def test_plot_global__should_warn_and_log_when_renderer_override_missing(
             threshold=None,
             use_legacy=False,
             show=False,
-            style="dummy-style",
             renderer="nope",
         )
 


### PR DESCRIPTION
# Pull Request

## Summary

This PR closes the release-blocking third-party plot-plugin dispatch defect found after `v1.0.0rc1`.

- Dispatches explicit and configured third-party factual, alternative, global, and dashboard styles before CE consumes plugin-owned plotting parameters.
- Adds strict style resolution without silently falling back to built-in rendering.
- Preserves complete plugin options, including `filter_top`, `uncertainty`, ranking controls, `bins`, `low_high_percentiles`, and nested vendor options.
- Adds trust-gated `PlotRenderContext.runtime` access for dashboard plugins without monkey-patching CE callables.
- Treats a renderer returning `None` as a successfully handled request.
- Recomputes trust after renderer overrides.
- Preserves configured third-party dispatch when `use_legacy=False`; configured `legacy` is bypassed in favor of `plot_spec.default`.
- Normalizes exact empty `filename` and `path` values to the historical “do not save” behavior.
- Uses requested regression percentiles when constructing global payload bounds, preventing numerically mislabelled intervals.
- Documents the public dispatch, transport, trust, and runtime contracts.
- Adds the plugin publication request template and related contribution guidance included in this branch.

The implementation is governed by [ADR-002](development/adrs/ADR-002-exception-hierarchy.md), [ADR-006](development/adrs/ADR-006-plugin-registry-trust-model.md), [ADR-020](development/adrs/ADR-020-legacy-user-api-stability.md), [ADR-028](development/adrs/ADR-028-logging-and-observability.md), [ADR-030](development/adrs/ADR-030-test-quality-method.md), [ADR-036](development/adrs/ADR-036-plotspec-canonical-contract.md), and [ADR-037](development/adrs/ADR-037-visualization-extension-governance.md).

## Checklist

- [x] Reviewed the `## Release preparation` section in the active [`v1.0.0-rc2_plan.md`](development/current-work/v1.0.0-rc2_plan.md#6-release-preparation-open)
- [x] Aligned with the [current v1.0.0rc2 phase](development/current-work/RELEASE_PLAN_v1.md#lightweight-release-control-master)
- [x] Referenced relevant ADRs: ADR-002, ADR-006, ADR-020, ADR-028, ADR-030, ADR-036, ADR-037
- [x] Added/updated tests for new or changed behavior
- [ ] Coverage gate passes (`pytest --cov=src/calibrated_explanations --cov-config=pyproject.toml --cov-fail-under=90`)
- [x] Coverage waiver requested (if needed) with linked issue: N/A
- [x] Legacy API parity verified (if wrapper/API changed) — no wrapper signature change; CE-owned style and `use_legacy` routes have targeted regression coverage
- [ ] mypy passes for touched modules (and strict for new core modules)
- [ ] Ruff and Markdown lint pass locally — Ruff passes for touched Python files; Markdown lint remains to run
- [x] Updated docs/README if public behavior or user flows changed
- [x] Considered backward compatibility and deprecation notes
- [ ] DCO sign-off added to commits (`git commit -s`)
- [ ] Reviewed CODE_OF_CONDUCT.md / SECURITY.md / GOVERNANCE.md as needed

## Screenshots/Notes (optional)

Focused verification completed:

- `86 passed` across the third-party dispatch, default-promotion, and plotting-coverage suites.
- Plotly no-bridge package suite: `233 passed, 3 skipped`.
- Fresh Python 3.11 installed-wheel proof passed:
  - non-default `(20, 80)` global regression bounds;
  - configured style with `use_legacy=False`;
  - empty `filename` behavior;
  - dashboard percentile inheritance and per-instance Mondrian-bin slicing;
  - configured `legacy` plus `use_legacy=False` resolving to `plot_spec.default`.
- Ruff and `git diff --check` pass for the touched files.
- CE plotting callable identities remain unchanged; no compatibility bridge or monkey patch is required.

## Breaking changes (if any)

- [x] N/A — no breaking changes; compatibility notes are documented in `CHANGELOG.md`