### PR TITLE
Update v1.0.1 plan: mark T2 as Done and add evidence for docstring coverage and nomenclature checks

### DIFF
--- a/development/current-work/v1.0.1_plan.md
+++ b/development/current-work/v1.0.1_plan.md
@@ -18,7 +18,7 @@ plugin category and does not enable cache or parallel execution by default.
 | ID | Deliverable | Issue | ADR/Standard | Status |
 |---|---|---|---|---|
 | T1 | Complete migration to issue- and milestone-based release planning | [#201](https://github.com/Moffran/calibrated_explanations/issues/201) | — | Done |
-| T2 | Re-run the Standard-002 docstring coverage gate and the Standard-001 nomenclature gate on the v1.0.1 candidate commit; compare against the v1.0.0 GA baseline (96.64% coverage, zero nomenclature violations) | [#199](https://github.com/Moffran/calibrated_explanations/issues/199) | STD-001, STD-002 | Not started |
+| T2 | Re-run the Standard-002 docstring coverage gate and the Standard-001 nomenclature gate on the v1.0.1 candidate commit; compare against the v1.0.0 GA baseline (96.64% coverage, zero nomenclature violations) | [#199](https://github.com/Moffran/calibrated_explanations/issues/199) | STD-001, STD-002 | Done |
 | T3 | Re-run the caching/parallel staging-equivalent smoke from `development/finished-work/v1.0.0-rc_plan.md` §3 and compare telemetry to the RC baseline (cache `hits=1, misses=1`; parallel `strategy="threads", workers=2, worker_utilisation_pct=100.0`) | [#200](https://github.com/Moffran/calibrated_explanations/issues/200) | ADR-003, ADR-004 | Not started |
 | T4 | Make wrapper auto-encoding operational and safe for mixed-type data | [#202](https://github.com/Moffran/calibrated_explanations/issues/202) | ADR-009 | Not started |
 | T5 | Make requested cache and parallel initialization failures explicit | [#209](https://github.com/Moffran/calibrated_explanations/issues/209) | ADR-003, ADR-004, ADR-028 | Not started |
@@ -57,7 +57,17 @@ plugin category and does not enable cache or parallel execution by default.
 
 ## Release decision
 
-`Not ready` — T1 is Done; T2-T6 are not yet complete.
+`Not ready` — T1 and T2 are Done; T3-T6 are not yet complete.
+
+T2 evidence (2026-09-02, commit `bdb68093`): `python
+scripts/quality/check_docstring_coverage.py --fail-under 94.0` → overall
+96.66% (Modules 99.17%, Classes 100.00%, Functions 95.09%, Methods 96.85%),
+at or above the v1.0.0 GA baseline of 96.64% — no regression. `python
+scripts/quality/check_std001_nomenclature.py --root src/calibrated_explanations
+--check` → 0 violations (`reports/nomenclature_violation_inventory.json`:
+`total_violations: 0`; 6 pre-approved `utility_import_bridge` records, all
+`is_allowed: true`), matching the v1.0.0 GA baseline of zero violations
+exactly. No corrective action required.
 
 T1 evidence (2026-07-22): `CONTRIBUTING.md`, `.github/CONTRIBUTING.md`,
 `.github/pull_request_template.md`, the `ce-release-planner`/`ce-release-task`/


### PR DESCRIPTION
Signed-off-by: Tuwe Löfström-Cavallin <tuwe.lofstrom@ju.se>

# Pull Request

## Summary

- Executes T2 of the v1.0.1 release plan: re-runs the STD-002 docstring
  coverage gate and the STD-001 nomenclature gate on the v1.0.1 candidate
  commit (`bdb68093`) and compares the results against the v1.0.0 GA
  baseline (96.64% coverage, zero nomenclature violations).
- Docstring coverage came back at 96.66% overall (Modules 99.17%, Classes
  100.00%, Functions 95.09%, Methods 96.85%) — at/above baseline, no
  regression.
- Nomenclature check came back at 0 violations — exact match to baseline
  (6 records present are pre-approved `utility_import_bridge` exceptions,
  all `is_allowed: true`).
- No regression was found, so no corrective source changes were needed.
  This PR only updates `development/current-work/v1.0.1_plan.md`: T2
  status flips to `Done`, and the `## Release decision` section gets a
  new evidence paragraph recording the commands run, their output, and
  the baseline comparison.

## Tracking

- Issue: Closes #199
- Active release task: T2
- Governing ADR or Standard: STD-001, STD-002

## Checklist

- [ ] Referenced relevant ADR(s) in `development/adrs/` (IDs) — N/A, governed by STD-001/STD-002, no ADR touched
- [ ] Added/updated tests for new or changed behavior — N/A, verification-only task, no source/behavior change
- [ ] Coverage gate passes (`pytest --cov=src/calibrated_explanations --cov-config=pyproject.toml --cov-fail-under=90`) — N/A, no source files changed
- [ ] Coverage waiver requested (if needed) with linked issue: N/A
- [ ] Legacy API parity verified (if wrapper/API changed) - ref ADR-020 — N/A, no wrapper/API change
- [ ] mypy passes for touched modules (and strict for new core modules) — N/A, no Python modules touched
- [x] Ruff and Markdown lint pass locally — `pre-commit run --files development/current-work/v1.0.1_plan.md` passed (codespell, end-of-file-fixer, mixed-line-ending, trailing-whitespace, check-added-large-files; ruff/bandit skipped, no Python files in the diff)
- [ ] Updated docs/README if public behavior or user flows changed — N/A, internal release-planning doc only, no public behavior changed
- [ ] Considered backward compatibility and deprecation notes — N/A, no API surface touched
- [x] DCO sign-off added to commits (`git commit -s`)
- [ ] Reviewed CODE_OF_CONDUCT.md / SECURITY.md / GOVERNANCE.md as needed — N/A, not applicable to this change

## Screenshots/Notes (optional)

Command output:

​```text
$ python scripts/quality/check_docstring_coverage.py --fail-under 94.0
Docstring coverage summary (Standard-018 baseline)
================================================
Modules   :  120/ 121 ( 99.17%)
Classes   :  156/ 156 (100.00%)
Functions :  620/ 652 ( 95.09%)
Methods   : 1013/1046 ( 96.85%)
------------------------------------------------
Overall    :  96.66%

$ python scripts/quality/check_std001_nomenclature.py --root src/calibrated_explanations --check
STD-001 nomenclature check passed (no disallowed violations).
Report written to reports\nomenclature_violation_inventory.json
# reports/nomenclature_violation_inventory.json -> total_violations: 0
​```

## Breaking changes (if any)

- [ ] Documented in CHANGELOG with migration notes — N/A, no breaking changes
